### PR TITLE
[FIX] 修复：贴图存在时，进行识别导致贴图窗口移动到侧边栏时的绘制错误

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,13 @@ nuget.exe
 # Serena LSP cache
 .serena/
 
-# Claude AI documentation (local-only)
+# AI documentation
 CLAUDE.md
 **/CLAUDE.md
+.claude/
+
+AGENTS.md
+
+# Test project build artifacts
+Tests/bin/
+Tests/obj/

--- a/Forms/Dialogs/FmScreenPaste.Designer.cs
+++ b/Forms/Dialogs/FmScreenPaste.Designer.cs
@@ -6,10 +6,16 @@
 
 		protected override void Dispose(bool disposing)
 		{
-			bool flag = disposing && this.components != null;
-			if (flag)
+			if (disposing)
 			{
-				this.components.Dispose();
+				var image = pasteImage;
+				pasteImage = null;
+				image?.Dispose();
+
+				if (components != null)
+				{
+					components.Dispose();
+				}
 			}
 			base.Dispose(disposing);
 		}

--- a/Forms/Dialogs/FmScreenPaste.cs
+++ b/Forms/Dialogs/FmScreenPaste.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.ComponentModel;
 using System.Drawing;
 using System.Drawing.Drawing2D;
@@ -6,31 +6,38 @@ using System.Drawing.Imaging;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Windows.Forms;
+using TrOCR.Helper;
 
 namespace TrOCR
 {
 
 	public partial class FmScreenPaste : Form
 	{
+		private OwnedImage pasteImage;
+		private bool isClosing;
 
 		public FmScreenPaste(Image img, Point LocationPoint)
 		{
+			if (img == null)
+			{
+				throw new ArgumentNullException(nameof(img));
+			}
+
 			m_aeroEnabled = false;
 			InitializeComponent();
-			BackgroundImage = img;
+			DoubleBuffered = true;
+
+			pasteImage = new OwnedImage(img);
 			Location = LocationPoint;
 			FormBorderStyle = FormBorderStyle.None;
 			MouseDown += Form1_MouseDown;
 			MouseMove += Form1_MouseMove;
 			MouseUp += Form1_MouseUp;
-			var size = img.Size;
-			MaximumSize = (MinimumSize = size);
+
+			var size = pasteImage.Size;
+			MaximumSize = MinimumSize = size;
 			Size = size;
 			MouseDoubleClick += 双击_MouseDoubleClick;
-		}
-
-		private void Form_MouseWheel(object sender, MouseEventArgs e)
-		{
 		}
 
 		private void RightCMS_Opening(object sender, CancelEventArgs e)
@@ -53,45 +60,96 @@ namespace TrOCR
 
 		private void 关闭ToolStripMenuItem_Click(object sender, EventArgs e)
 		{
-			BackgroundImage.Dispose();
-			GC.Collect();
-			Close();
+			CloseAndDisposeImage();
 		}
 
 		private void 复制toolStripMenuItem_Click(object sender, EventArgs e)
 		{
-			Clipboard.SetImage(BackgroundImage);
+			if (pasteImage == null || !pasteImage.IsUsable)
+			{
+				CommonHelper.ShowHelpMsg("贴图已失效");
+				CloseAndDisposeImage();
+				return;
+			}
+
+			using (var copy = pasteImage.CloneBitmap())
+			{
+				if (!ClipboardHelper.TrySetDataObject(copy, out var errorMessage))
+				{
+					CommonHelper.ShowHelpMsg("复制失败：剪贴板被占用", 1600u);
+					System.Diagnostics.Debug.WriteLine(errorMessage);
+				}
+			}
 		}
 
 		private void 保存toolStripMenuItem_Click(object sender, EventArgs e)
 		{
-			var saveFileDialog = new SaveFileDialog();
-			saveFileDialog.Filter = "jpg图片(*.jpg)|*.jpg|png图片(*.png)|*.jpg|bmp图片(*.bmp)|*.bmp";
-			saveFileDialog.AddExtension = false;
-			saveFileDialog.FileName = string.Concat("tianruo_", DateTime.Now.Year.ToString(), "-", DateTime.Now.Month.ToString(), "-", DateTime.Now.Day.ToString(), "-", DateTime.Now.Ticks.ToString());
-			saveFileDialog.Title = "保存图片";
-			saveFileDialog.FilterIndex = 1;
-			saveFileDialog.RestoreDirectory = true;
-			var flag = saveFileDialog.ShowDialog() == DialogResult.OK;
-			if (flag)
+			if (pasteImage == null || !pasteImage.IsUsable)
 			{
+				CommonHelper.ShowHelpMsg("贴图已失效");
+				CloseAndDisposeImage();
+				return;
+			}
+
+			using (var saveFileDialog = new SaveFileDialog())
+			{
+				saveFileDialog.Filter = "jpg图片(*.jpg)|*.jpg|png图片(*.png)|*.png|bmp图片(*.bmp)|*.bmp";
+				saveFileDialog.AddExtension = false;
+				saveFileDialog.FileName = string.Concat("tianruo_", DateTime.Now.Year, "-", DateTime.Now.Month, "-", DateTime.Now.Day, "-", DateTime.Now.Ticks);
+				saveFileDialog.Title = "保存图片";
+				saveFileDialog.FilterIndex = 1;
+				saveFileDialog.RestoreDirectory = true;
+
+				if (saveFileDialog.ShowDialog() != DialogResult.OK)
+				{
+					return;
+				}
+
 				var extension = Path.GetExtension(saveFileDialog.FileName);
-				var flag2 = extension.Equals(".jpg");
-				if (flag2)
+				var format = GetImageFormat(extension);
+				if (format == null)
 				{
-					BackgroundImage.Save(saveFileDialog.FileName, ImageFormat.Jpeg);
+					CommonHelper.ShowHelpMsg("不支持的图片格式");
+					return;
 				}
-				var flag3 = extension.Equals(".png");
-				if (flag3)
+
+				try
 				{
-					BackgroundImage.Save(saveFileDialog.FileName, ImageFormat.Png);
+					pasteImage.Bitmap.Save(saveFileDialog.FileName, format);
 				}
-				var flag4 = extension.Equals(".bmp");
-				if (flag4)
+				catch (ExternalException ex)
 				{
-					BackgroundImage.Save(saveFileDialog.FileName, ImageFormat.Bmp);
+					CommonHelper.ShowHelpMsg("保存失败");
+					System.Diagnostics.Debug.WriteLine("贴图保存失败: " + ex);
+				}
+				catch (ArgumentException ex)
+				{
+					CommonHelper.ShowHelpMsg("贴图已失效");
+					System.Diagnostics.Debug.WriteLine("贴图保存失败: " + ex);
+					CloseAndDisposeImage();
 				}
 			}
+		}
+
+		private static ImageFormat GetImageFormat(string extension)
+		{
+			if (string.Equals(extension, ".jpg", StringComparison.OrdinalIgnoreCase) ||
+				string.Equals(extension, ".jpeg", StringComparison.OrdinalIgnoreCase))
+			{
+				return ImageFormat.Jpeg;
+			}
+
+			if (string.Equals(extension, ".png", StringComparison.OrdinalIgnoreCase))
+			{
+				return ImageFormat.Png;
+			}
+
+			if (string.Equals(extension, ".bmp", StringComparison.OrdinalIgnoreCase))
+			{
+				return ImageFormat.Bmp;
+			}
+
+			return null;
 		}
 
 		[DllImport("user32.dll")]
@@ -180,8 +238,17 @@ namespace TrOCR
 
 		private void 双击_MouseDoubleClick(object sender, MouseEventArgs e)
 		{
-			BackgroundImage.Dispose();
-			GC.Collect();
+			CloseAndDisposeImage();
+		}
+
+		private void CloseAndDisposeImage()
+		{
+			if (isClosing)
+			{
+				return;
+			}
+
+			isClosing = true;
 			Close();
 		}
 
@@ -224,23 +291,44 @@ namespace TrOCR
 
 		protected override void OnPaint(PaintEventArgs e)
 		{
-			DoubleBuffered = true;
-			var flag = BackgroundImage != null;
-			if (flag)
+			if (pasteImage == null || !pasteImage.IsUsable)
 			{
-				e.Graphics.SmoothingMode = SmoothingMode.HighQuality;
-				e.Graphics.DrawImage(BackgroundImage, new Rectangle(0, 0, Width, Height), 0, 0, BackgroundImage.Width, BackgroundImage.Height, GraphicsUnit.Pixel);
+				base.OnPaint(e);
+				return;
 			}
+
+			try
+			{
+				var image = pasteImage.Bitmap;
+				e.Graphics.SmoothingMode = SmoothingMode.HighQuality;
+				e.Graphics.DrawImage(
+					image,
+					new Rectangle(0, 0, Width, Height),
+					0,
+					0,
+					image.Width,
+					image.Height,
+					GraphicsUnit.Pixel);
+			}
+			catch (ArgumentException ex)
+			{
+				System.Diagnostics.Debug.WriteLine("贴图窗口绘制失败: " + ex.Message);
+				CloseAndDisposeImage();
+				return;
+			}
+			catch (ObjectDisposedException ex)
+			{
+				System.Diagnostics.Debug.WriteLine("贴图窗口图像已释放: " + ex.Message);
+				CloseAndDisposeImage();
+				return;
+			}
+
 			base.OnPaint(e);
 		}
 
 		protected override void OnPaintBackground(PaintEventArgs e)
 		{
 		}
-
-		private int zoomLevel;
-
-		private string ScreenshotLastSavePath;
 
 		private bool m_aeroEnabled;
 

--- a/Forms/Main/FmMain.Clipboard.cs
+++ b/Forms/Main/FmMain.Clipboard.cs
@@ -22,19 +22,14 @@ namespace TrOCR
 			if (isAppLoading)
 			{
 				isAppLoading = false; // 将标志位置为false，确保此逻辑只执行一次
-                // 使用 try-catch 保护剪贴板读取，防止启动时其他程序占用剪贴板导致崩溃
-                try
+                if (!ClipboardHelper.TryGetText(out var startupClipboardText, out var startupClipboardError))
                 {
-                    if (Clipboard.ContainsText())
-                    {
-                        // 同步初始的剪贴板内容，以便下一次真正的复制可以被正确比较
-                        lastClipboardText = Clipboard.GetText();
-                    }
+                    Debug.WriteLine(startupClipboardError);
                 }
-                catch (Exception ex)
+                else if (!string.IsNullOrEmpty(startupClipboardText))
                 {
-                    Debug.WriteLine("程序启动时同步剪贴板状态失败: " + ex.Message);
-                    // 启动时读取失败没关系，直接忽略即可，不影响后续监听
+                    // 同步初始的剪贴板内容，以便下一次真正的复制可以被正确比较
+                    lastClipboardText = startupClipboardText;
                 }
                 return; // 关键：直接退出，不执行任何后续的翻译操作
 			}
@@ -57,19 +52,10 @@ namespace TrOCR
 		    // 1. 首先停止定时器，防止重复执行
 		    clipboardDebounceTimer.Stop();
 
-            string clipboardText = null;
-
-            // 2. 将 ContainsText 和 GetText 全部放入 try-catch 中
-            try
+            // 2. 通过 ClipboardHelper 读取剪贴板，统一获得重试与诊断
+            if (!ClipboardHelper.TryGetText(out var clipboardText, out var clipboardError))
             {
-                if (Clipboard.ContainsText())
-                {
-                    clipboardText = Clipboard.GetText();
-                }
-            }
-            catch (Exception ex)
-            {
-                Debug.WriteLine("获取剪贴板文本失败，可能被其他程序占用: " + ex.Message);
+                Debug.WriteLine(clipboardError);
                 return; // 获取失败则直接返回，等待下一次用户复制
             }
 

--- a/Forms/Main/FmMain.Clipboard.cs
+++ b/Forms/Main/FmMain.Clipboard.cs
@@ -116,12 +116,17 @@ namespace TrOCR
 				SendKeys.SendWait("^c");
 				SendKeys.Flush();
 			}
-			var text = Clipboard.GetText();
-			text = (string.IsNullOrWhiteSpace(text) ? null : text);
-			// 如果获取到文本内容，则清空剪贴板
-			if (text != null)
+				if (!ClipboardHelper.TryGetText(out var text, out var clipError))
 			{
-				Clipboard.Clear();
+				Debug.WriteLine(clipError);
+				CommonHelper.ShowHelpMsg("剪贴板被占用，读取失败", 1600u);
+				return null;
+			}
+
+			text = string.IsNullOrWhiteSpace(text) ? null : text;
+			if (text != null && !ClipboardHelper.TryClear(out clipError))
+			{
+				Debug.WriteLine(clipError);
 			}
 			return text;
 		}
@@ -132,10 +137,8 @@ namespace TrOCR
         /// <param name="data">要复制到剪贴板的对象 (可以是 string, DataObject, Image 等)。</param>
         public void SetClipboardWithLock(object data)
         {
-            // 检查传入的对象是否为 null
             if (data == null) return;
 
-            // 如果传入的是字符串，额外检查它是否为空或仅包含空白字符
             if (data is string textData && string.IsNullOrWhiteSpace(textData))
             {
                 return;
@@ -143,22 +146,24 @@ namespace TrOCR
 
             try
             {
-                // 1. 激活状态锁
                 isAutoCopying = true;
                 Debug.WriteLine("--- 剪贴板锁已激活 ---");
 
-                // 2. 执行复制操作
-                // 这个调用现在是通用的，可以处理 string、DataObject 等多种类型
-                Clipboard.SetDataObject(data, true, 5, 100);
+                if (!ClipboardHelper.TrySetDataObject(data, out var errorMessage))
+                {
+                    CommonHelper.ShowHelpMsg("剪贴板被占用，复制失败", 1600u);
+                    Debug.WriteLine(errorMessage);
+                    isAutoCopying = false;
+                    autoCopyLockTimer.Stop();
+                    return;
+                }
 
-                // 3. 启动定时器，创建静默期
-                autoCopyLockTimer.Stop(); // 确保定时器被重置
+                autoCopyLockTimer.Stop();
                 autoCopyLockTimer.Start();
             }
             catch (Exception ex)
             {
-                System.Diagnostics.Debug.WriteLine($"带锁设置剪贴板失败: {ex.Message}");
-                // 如果复制失败，必须立即解除锁定
+                Debug.WriteLine($"带锁设置剪贴板失败: {ex.Message}");
                 isAutoCopying = false;
                 autoCopyLockTimer.Stop();
             }
@@ -177,14 +182,22 @@ namespace TrOCR
             {
                 isAutoCopying = true;
                 Debug.WriteLine("--- 剪贴板锁已激活 (Data) ---");
-                // 此调用处理 Clipboard.SetData 的情况
-                Clipboard.SetData(format, data);
+
+                if (!ClipboardHelper.TrySetData(format, data, out var errorMessage))
+                {
+                    CommonHelper.ShowHelpMsg("剪贴板被占用，复制失败", 1600u);
+                    Debug.WriteLine(errorMessage);
+                    isAutoCopying = false;
+                    autoCopyLockTimer.Stop();
+                    return;
+                }
+
                 autoCopyLockTimer.Stop();
                 autoCopyLockTimer.Start();
             }
             catch (Exception ex)
             {
-                System.Diagnostics.Debug.WriteLine($"带锁设置剪贴板数据失败: {ex.Message}");
+                Debug.WriteLine($"带锁设置剪贴板数据失败: {ex.Message}");
                 isAutoCopying = false;
                 autoCopyLockTimer.Stop();
             }

--- a/Forms/Main/FmMain.OCR.Core.cs
+++ b/Forms/Main/FmMain.OCR.Core.cs
@@ -223,8 +223,24 @@ namespace TrOCR
 								}
 								if (modeFlag == "截图")
 								{
-									// 截图模式：将图像复制到剪贴板
-									Clipboard.SetImage(image_screen);
+									using (var copy = ImageHelper.CloneBitmap(image_screen))
+									{
+										if (!ClipboardHelper.TrySetDataObject(copy, out var errorMessage))
+										{
+											CommonHelper.ShowHelpMsg("剪贴板被占用，截图复制失败", 1600u);
+											Debug.WriteLine(errorMessage);
+										}
+										else
+										{
+											if (IniHelper.GetValue("截图音效", "粘贴板") == "True")
+											{
+												PlaySong(IniHelper.GetValue("截图音效", "音效路径"));
+											}
+
+											CommonHelper.ShowHelpMsg("已复制截图");
+										}
+									}
+
 									if (IniHelper.GetValue("快捷键", "翻译文本") != "请按下快捷键")
 									{
 										var value5 = IniHelper.GetValue("快捷键", "翻译文本");
@@ -234,11 +250,6 @@ namespace TrOCR
 									}
 									HelpWin32.UnregisterHotKey(Handle, 222);
 									StaticValue.IsCapture = false;
-									if (IniHelper.GetValue("截图音效", "粘贴板") == "True")
-									{
-										PlaySong(IniHelper.GetValue("截图音效", "音效路径"));
-									}
-									CommonHelper.ShowHelpMsg("已复制截图");
 								}
 								else if (modeFlag == "自动保存" && IniHelper.GetValue("配置", "自动保存") == "True")
 								{

--- a/Forms/Main/FmMain.Translation.cs
+++ b/Forms/Main/FmMain.Translation.cs
@@ -839,7 +839,14 @@ namespace TrOCR
 			SendKeys.SendWait("^c");
 			SendKeys.Flush();
 			RichBoxBody.richTextBox1.TextChanged -= RichBoxBody_TextChanged;
-			RichBoxBody.Text = Clipboard.GetText();
+			if (!ClipboardHelper.TryGetText(out var clipText, out var clipErr))
+			{
+				Debug.WriteLine(clipErr);
+				CommonHelper.ShowHelpMsg("剪贴板被占用，读取失败", 1600u);
+				RichBoxBody.richTextBox1.TextChanged += RichBoxBody_TextChanged;
+				return;
+			}
+			RichBoxBody.Text = clipText;
 			// RichBoxBody.richTextBox1.TextChanged += RichBoxBody_TextChanged;
             // 1. 先让窗口以正常状态显示出来
             FormBorderStyle = FormBorderStyle.Sizable;

--- a/Forms/Main/FmMain.Tray.cs
+++ b/Forms/Main/FmMain.Tray.cs
@@ -509,10 +509,11 @@ namespace TrOCR
 			RichBoxBody.richTextBox1.TextChanged -= RichBoxBody_TextChanged; // 关键：在设置文本前，先断开事件处理，避免触发不必要的逻辑
 			try
 			{
-				if (StaticValue.InputTranslateClipboard && Clipboard.ContainsText())
+				string clipboardText = null;
+				string clipboardError = null;
+				if (StaticValue.InputTranslateClipboard && ClipboardHelper.TryGetText(out clipboardText, out clipboardError) && !string.IsNullOrEmpty(clipboardText))
 				{
-					string clipboardText = Clipboard.GetText();
-					string textToDisplay = clipboardText; // 默认显示原始剪贴板文本
+					string textToDisplay = clipboardText;
 
 					// --- 新增的核心逻辑：检查并执行自动合并 ---
 					if (bool.Parse(IniHelper.GetValue("工具栏", "合并"))) // 检查是否开启了自动合并
@@ -549,6 +550,10 @@ namespace TrOCR
 				}
 				else
 				{
+					if (!string.IsNullOrEmpty(clipboardError))
+					{
+						Debug.WriteLine(clipboardError);
+					}
 					RichBoxBody.Text = "";
 				}
 			}

--- a/Tests/ClipboardHelperTests.cs
+++ b/Tests/ClipboardHelperTests.cs
@@ -7,6 +7,10 @@ using TrOCR.Helper;
 
 namespace TrOCR.Tests
 {
+    /// <summary>
+    /// 验证 <see cref="ClipboardHelper"/> 在剪贴板被占用、参数异常等边界条件下的行为。
+    /// 确保重试机制和诊断消息按预期工作，不会因外部剪贴板竞争导致未处理异常。
+    /// </summary>
     [TestFixture]
     public class ClipboardHelperTests
     {
@@ -16,6 +20,10 @@ namespace TrOCR.Tests
         [DllImport("user32.dll", SetLastError = true)]
         private static extern bool CloseClipboard();
 
+        /// <summary>
+        /// 当传入 null 数据时，TrySetDataObject 应视为无操作并返回成功，不产生错误消息。
+        /// 防御调用方未做空值检查就透传给 ClipboardHelper 的场景。
+        /// </summary>
         [Test]
         public void TrySetDataObject_NullData_ReturnsTrueWithoutError()
         {
@@ -25,6 +33,10 @@ namespace TrOCR.Tests
             Assert.That(errorMessage, Is.Null);
         }
 
+        /// <summary>
+        /// 验证诊断消息构建方法包含用户友好提示和原始异常信息，
+        /// 确保开发者和用户都能从消息中获得有效信息。
+        /// </summary>
         [Test]
         public void BuildClipboardErrorMessage_IncludesOriginalErrorMessage()
         {
@@ -34,6 +46,11 @@ namespace TrOCR.Tests
             Assert.That(message, Does.Contain("open clipboard failed"));
         }
 
+        /// <summary>
+        /// 模拟另一线程持有剪贴板锁的场景，验证 TrySetDataObject 在重试耗尽后
+        /// 返回 false 并提供包含诊断信息的错误消息，而非抛出异常。
+        /// 标记为 Explicit：使用全局 Windows 剪贴板，需手动运行。
+        /// </summary>
         [Test]
         [Explicit("Uses the global Windows clipboard. Run manually when validating clipboard-lock behavior.")]
         [Apartment(ApartmentState.STA)]

--- a/Tests/ClipboardHelperTests.cs
+++ b/Tests/ClipboardHelperTests.cs
@@ -1,0 +1,98 @@
+using System;
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+using System.Threading;
+using NUnit.Framework;
+using TrOCR.Helper;
+
+namespace TrOCR.Tests
+{
+    [TestFixture]
+    public class ClipboardHelperTests
+    {
+        [DllImport("user32.dll", SetLastError = true)]
+        private static extern bool OpenClipboard(IntPtr hWndNewOwner);
+
+        [DllImport("user32.dll", SetLastError = true)]
+        private static extern bool CloseClipboard();
+
+        [Test]
+        public void TrySetDataObject_NullData_ReturnsTrueWithoutError()
+        {
+            var result = ClipboardHelper.TrySetDataObject(null, out var errorMessage);
+
+            Assert.That(result, Is.True);
+            Assert.That(errorMessage, Is.Null);
+        }
+
+        [Test]
+        public void BuildClipboardErrorMessage_IncludesOriginalErrorMessage()
+        {
+            var message = ClipboardHelper.BuildClipboardErrorMessage(new InvalidOperationException("open clipboard failed"));
+
+            Assert.That(message, Does.Contain("剪贴板暂时不可用"));
+            Assert.That(message, Does.Contain("open clipboard failed"));
+        }
+
+        [Test]
+        [Explicit("Uses the global Windows clipboard. Run manually when validating clipboard-lock behavior.")]
+        [Apartment(ApartmentState.STA)]
+        public void TrySetDataObject_WhenClipboardHeldByAnotherThread_ReturnsFalseWithDiagnostic()
+        {
+            using (var clipboardOpened = new ManualResetEventSlim(false))
+            using (var releaseClipboard = new ManualResetEventSlim(false))
+            {
+                Exception holderException = null;
+                var holderThread = new Thread(() =>
+                {
+                    var opened = false;
+                    try
+                    {
+                        opened = OpenClipboard(IntPtr.Zero);
+                        if (!opened)
+                        {
+                            throw new Win32Exception(Marshal.GetLastWin32Error());
+                        }
+
+                        clipboardOpened.Set();
+                        releaseClipboard.Wait(TimeSpan.FromSeconds(10));
+                    }
+                    catch (Exception ex)
+                    {
+                        holderException = ex;
+                        clipboardOpened.Set();
+                    }
+                    finally
+                    {
+                        if (opened)
+                        {
+                            CloseClipboard();
+                        }
+                    }
+                });
+
+                holderThread.SetApartmentState(ApartmentState.STA);
+                holderThread.Start();
+
+                Assert.That(clipboardOpened.Wait(TimeSpan.FromSeconds(3)), Is.True, "clipboard holder thread did not start");
+                if (holderException != null)
+                {
+                    Assert.Fail("clipboard holder thread failed: " + holderException);
+                }
+
+                try
+                {
+                    var result = ClipboardHelper.TrySetDataObject("clipboard-lock-test", out var errorMessage);
+
+                    Assert.That(result, Is.False);
+                    Assert.That(errorMessage, Does.Contain("剪贴板暂时不可用"));
+                }
+                finally
+                {
+                    releaseClipboard.Set();
+                    Assert.That(holderThread.Join(TimeSpan.FromSeconds(3)), Is.True, "clipboard holder thread did not exit");
+                }
+            }
+        }
+    }
+}

--- a/Tests/ClipboardUsageTests.cs
+++ b/Tests/ClipboardUsageTests.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using NUnit.Framework;
+
+namespace TrOCR.Tests
+{
+    /// <summary>
+    /// 架构边界守卫测试：静态扫描 Forms 目录下所有 .cs 文件，
+    /// 确保业务代码不直接调用 System.Windows.Forms.Clipboard 的静态 API。
+    /// 所有剪贴板操作必须通过 ClipboardHelper 统一获得重试、诊断和异常保护。
+    /// </summary>
+    [TestFixture]
+    public class ClipboardUsageTests
+    {
+        /// <summary>
+        /// 扫描 Forms/**/*.cs 中是否存在对 Clipboard.GetText/ContainsText/SetImage 等
+        /// 静态方法的直接调用。如发现违规，测试失败并列出具体文件和行号。
+        /// </summary>
+        [Test]
+        public void Forms_DoNotCallWindowsClipboardDirectly()
+        {
+            var repositoryRoot = FindRepositoryRoot();
+            var formsDirectory = Path.Combine(repositoryRoot, "Forms");
+
+            var violations = Directory
+                .EnumerateFiles(formsDirectory, "*.cs", SearchOption.AllDirectories)
+                .SelectMany(filePath => FindClipboardCalls(repositoryRoot, filePath))
+                .ToArray();
+
+            Assert.That(
+                violations,
+                Is.Empty,
+                "Forms code should use ClipboardHelper for retry and diagnostics:"
+                + Environment.NewLine
+                + string.Join(Environment.NewLine, violations));
+        }
+
+        private static readonly Regex ClipboardApiPattern = new Regex(
+            @"\bClipboard\.(GetText|SetText|ContainsText|GetImage|SetImage|GetDataObject|SetDataObject|SetData|GetData|ContainsImage|ContainsData|Clear)\b",
+            RegexOptions.Compiled);
+
+        private static IEnumerable<string> FindClipboardCalls(string repositoryRoot, string filePath)
+        {
+            return File
+                .ReadLines(filePath)
+                .Select((line, index) => new { line, lineNumber = index + 1 })
+                .Where(item => ClipboardApiPattern.IsMatch(item.line))
+                .Select(item => $"{GetRelativePath(repositoryRoot, filePath)}:{item.lineNumber}: {item.line.Trim()}");
+        }
+
+        private static string FindRepositoryRoot()
+        {
+            var directory = TestContext.CurrentContext.TestDirectory;
+            while (!string.IsNullOrEmpty(directory))
+            {
+                if (File.Exists(Path.Combine(directory, "TrOCR.sln")))
+                {
+                    return directory;
+                }
+
+                directory = Directory.GetParent(directory)?.FullName;
+            }
+
+            throw new DirectoryNotFoundException("无法从测试输出目录定位仓库根目录: " + TestContext.CurrentContext.TestDirectory);
+        }
+
+        private static string GetRelativePath(string rootDirectory, string filePath)
+        {
+            var root = Path.GetFullPath(rootDirectory)
+                .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+                + Path.DirectorySeparatorChar;
+            var path = Path.GetFullPath(filePath);
+
+            if (!path.StartsWith(root, StringComparison.OrdinalIgnoreCase))
+            {
+                return path;
+            }
+
+            return path.Substring(root.Length);
+        }
+    }
+}

--- a/Tests/FmScreenPasteTests.cs
+++ b/Tests/FmScreenPasteTests.cs
@@ -1,0 +1,48 @@
+using System.Drawing;
+using System.Threading;
+using System.Windows.Forms;
+using NUnit.Framework;
+using TrOCR.Tests.TestSupport;
+
+namespace TrOCR.Tests
+{
+    [TestFixture]
+    public class FmScreenPasteTests
+    {
+        [Test]
+        [Apartment(ApartmentState.STA)]
+        public void OnPaint_SourceImageDisposedAfterConstruction_RendersOwnedCopy()
+        {
+            var expectedColor = Color.FromArgb(255, 201, 44, 90);
+            var source = TestImageFactory.CreateSolidBitmap(16, 12, expectedColor);
+
+            using (var form = new TestableFmScreenPaste(source))
+            {
+                source.Dispose();
+
+                using (var target = new Bitmap(form.Width, form.Height))
+                using (var graphics = Graphics.FromImage(target))
+                {
+                    Assert.DoesNotThrow(() => form.PaintForTest(graphics));
+                    Assert.That(target.GetPixel(8, 6).ToArgb(), Is.EqualTo(expectedColor.ToArgb()));
+                }
+            }
+        }
+
+        private sealed class TestableFmScreenPaste : FmScreenPaste
+        {
+            public TestableFmScreenPaste(Image image)
+                : base(image, Point.Empty)
+            {
+            }
+
+            public void PaintForTest(Graphics graphics)
+            {
+                using (var args = new PaintEventArgs(graphics, new Rectangle(Point.Empty, Size)))
+                {
+                    base.OnPaint(args);
+                }
+            }
+        }
+    }
+}

--- a/Tests/FmScreenPasteTests.cs
+++ b/Tests/FmScreenPasteTests.cs
@@ -6,9 +6,18 @@ using TrOCR.Tests.TestSupport;
 
 namespace TrOCR.Tests
 {
+    /// <summary>
+    /// 验证贴图窗口 <see cref="FmScreenPaste"/> 持有源图像的独立副本，
+    /// 即使外部调用方释放了传入的 Image 实例，窗口绘制仍能正常工作而不抛出异常。
+    /// 回归保护：commit 6e05465 修复的"贴图红叉"崩溃。
+    /// </summary>
     [TestFixture]
     public class FmScreenPasteTests
     {
+        /// <summary>
+        /// 构造贴图窗口后立即释放源图像，随后触发 OnPaint。
+        /// 验证窗口内部持有深拷贝，渲染输出像素与原始颜色一致。
+        /// </summary>
         [Test]
         [Apartment(ApartmentState.STA)]
         public void OnPaint_SourceImageDisposedAfterConstruction_RendersOwnedCopy()

--- a/Tests/ImageHelperTests.cs
+++ b/Tests/ImageHelperTests.cs
@@ -6,9 +6,17 @@ using TrOCR.Tests.TestSupport;
 
 namespace TrOCR.Tests
 {
+    /// <summary>
+    /// 验证 <see cref="ImageHelper"/> 提供的图像深拷贝和可用性检测工具方法。
+    /// 确保 CloneBitmap 生成完全独立的副本，IsUsable 能正确识别已释放或空引用的图像。
+    /// </summary>
     [TestFixture]
     public class ImageHelperTests
     {
+        /// <summary>
+        /// 克隆后释放源图像，验证克隆副本的尺寸和像素数据仍完整可用，
+        /// 且可被 GDI+ 正常绘制（无 InvalidOperationException）。
+        /// </summary>
         [Test]
         public void CloneBitmap_SourceDisposed_CloneRemainsUsable()
         {
@@ -31,12 +39,19 @@ namespace TrOCR.Tests
             }
         }
 
+        /// <summary>
+        /// 传入 null 时应抛出 ArgumentNullException，防止空引用在后续流程中延迟暴露。
+        /// </summary>
         [Test]
         public void CloneBitmap_NullSource_ThrowsArgumentNullException()
         {
             Assert.Throws<ArgumentNullException>(() => ImageHelper.CloneBitmap(null));
         }
 
+        /// <summary>
+        /// 已释放的 Image 实例应被判定为不可用，返回 false。
+        /// 用于绘制前的安全检查，避免 GDI+ 报错。
+        /// </summary>
         [Test]
         public void IsUsable_DisposedImage_ReturnsFalse()
         {
@@ -46,6 +61,9 @@ namespace TrOCR.Tests
             Assert.That(ImageHelper.IsUsable(image), Is.False);
         }
 
+        /// <summary>
+        /// null 引用应被判定为不可用，返回 false。
+        /// </summary>
         [Test]
         public void IsUsable_NullImage_ReturnsFalse()
         {

--- a/Tests/ImageHelperTests.cs
+++ b/Tests/ImageHelperTests.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Drawing;
+using NUnit.Framework;
+using TrOCR.Helper;
+using TrOCR.Tests.TestSupport;
+
+namespace TrOCR.Tests
+{
+    [TestFixture]
+    public class ImageHelperTests
+    {
+        [Test]
+        public void CloneBitmap_SourceDisposed_CloneRemainsUsable()
+        {
+            var expectedColor = Color.FromArgb(255, 17, 34, 51);
+            var source = TestImageFactory.CreateSolidBitmap(12, 8, expectedColor);
+
+            using (var clone = ImageHelper.CloneBitmap(source))
+            {
+                source.Dispose();
+
+                Assert.That(clone.Width, Is.EqualTo(12));
+                Assert.That(clone.Height, Is.EqualTo(8));
+                Assert.That(clone.GetPixel(6, 4).ToArgb(), Is.EqualTo(expectedColor.ToArgb()));
+
+                using (var redrawTarget = new Bitmap(clone.Width, clone.Height))
+                using (var graphics = Graphics.FromImage(redrawTarget))
+                {
+                    Assert.DoesNotThrow(() => graphics.DrawImage(clone, 0, 0));
+                }
+            }
+        }
+
+        [Test]
+        public void CloneBitmap_NullSource_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => ImageHelper.CloneBitmap(null));
+        }
+
+        [Test]
+        public void IsUsable_DisposedImage_ReturnsFalse()
+        {
+            var image = TestImageFactory.CreateSolidBitmap(4, 3, Color.Red);
+            image.Dispose();
+
+            Assert.That(ImageHelper.IsUsable(image), Is.False);
+        }
+
+        [Test]
+        public void IsUsable_NullImage_ReturnsFalse()
+        {
+            Assert.That(ImageHelper.IsUsable(null), Is.False);
+        }
+    }
+}

--- a/Tests/OwnedImageTests.cs
+++ b/Tests/OwnedImageTests.cs
@@ -6,9 +6,18 @@ using TrOCR.Tests.TestSupport;
 
 namespace TrOCR.Tests
 {
+    /// <summary>
+    /// 验证 <see cref="OwnedImage"/> 的所有权语义：
+    /// 构造时深拷贝源图像使其独立于外部生命周期，Dispose 后禁止访问内部位图。
+    /// 这是贴图窗口和截图流程中图像安全管理的基础设施。
+    /// </summary>
     [TestFixture]
     public class OwnedImageTests
     {
+        /// <summary>
+        /// 构造 OwnedImage 后释放源图像，验证内部副本仍可用，
+        /// 尺寸、像素数据正确，且 CloneBitmap 能再次生成独立副本。
+        /// </summary>
         [Test]
         public void Constructor_SourceDisposed_OwnedBitmapRemainsUsable()
         {
@@ -33,6 +42,10 @@ namespace TrOCR.Tests
             }
         }
 
+        /// <summary>
+        /// Dispose 后 IsUsable 应返回 false，访问 Bitmap 属性应抛出 ObjectDisposedException。
+        /// 确保已释放的 OwnedImage 不会被误用于绘制。
+        /// </summary>
         [Test]
         public void Dispose_AccessingBitmap_ThrowsObjectDisposedException()
         {

--- a/Tests/OwnedImageTests.cs
+++ b/Tests/OwnedImageTests.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Drawing;
+using NUnit.Framework;
+using TrOCR.Helper;
+using TrOCR.Tests.TestSupport;
+
+namespace TrOCR.Tests
+{
+    [TestFixture]
+    public class OwnedImageTests
+    {
+        [Test]
+        public void Constructor_SourceDisposed_OwnedBitmapRemainsUsable()
+        {
+            var expectedColor = Color.FromArgb(255, 80, 120, 160);
+            var source = TestImageFactory.CreateSolidBitmap(10, 7, expectedColor);
+
+            using (var owned = new OwnedImage(source))
+            {
+                source.Dispose();
+
+                Assert.That(owned.IsUsable, Is.True);
+                Assert.That(owned.Width, Is.EqualTo(10));
+                Assert.That(owned.Height, Is.EqualTo(7));
+                Assert.That(owned.Bitmap.GetPixel(5, 3).ToArgb(), Is.EqualTo(expectedColor.ToArgb()));
+
+                using (var copy = owned.CloneBitmap())
+                {
+                    Assert.That(copy.Width, Is.EqualTo(10));
+                    Assert.That(copy.Height, Is.EqualTo(7));
+                    Assert.That(copy.GetPixel(5, 3).ToArgb(), Is.EqualTo(expectedColor.ToArgb()));
+                }
+            }
+        }
+
+        [Test]
+        public void Dispose_AccessingBitmap_ThrowsObjectDisposedException()
+        {
+            var source = TestImageFactory.CreateSolidBitmap(3, 2, Color.Blue);
+            var owned = new OwnedImage(source);
+
+            owned.Dispose();
+            source.Dispose();
+
+            Assert.That(owned.IsUsable, Is.False);
+            Assert.Throws<ObjectDisposedException>(() =>
+            {
+                var ignored = owned.Bitmap;
+            });
+        }
+    }
+}

--- a/Tests/Stubs/CommonHelperStub.cs
+++ b/Tests/Stubs/CommonHelperStub.cs
@@ -1,0 +1,26 @@
+namespace TrOCR.Helper
+{
+    public static class CommonHelper
+    {
+        public static string LastMessage { get; private set; }
+
+        public static uint LastDurationMs { get; private set; }
+
+        public static void ShowHelpMsg(string msg)
+        {
+            ShowHelpMsg(msg, 600u);
+        }
+
+        public static void ShowHelpMsg(string msg, uint durationMs)
+        {
+            LastMessage = msg;
+            LastDurationMs = durationMs;
+        }
+
+        public static void Reset()
+        {
+            LastMessage = null;
+            LastDurationMs = 0u;
+        }
+    }
+}

--- a/Tests/Stubs/CommonHelperStub.cs
+++ b/Tests/Stubs/CommonHelperStub.cs
@@ -1,5 +1,9 @@
 namespace TrOCR.Helper
 {
+    /// <summary>
+    /// CommonHelper 的测试桩实现。测试项目通过 Compile Include 直接编译 FmScreenPaste 等生产源码，
+    /// 这些代码引用了 CommonHelper.ShowHelpMsg，此桩提供无副作用的替代实现以满足编译依赖。
+    /// </summary>
     public static class CommonHelper
     {
         public static string LastMessage { get; private set; }

--- a/Tests/TestSupport/TestImageFactory.cs
+++ b/Tests/TestSupport/TestImageFactory.cs
@@ -1,0 +1,18 @@
+using System.Drawing;
+
+namespace TrOCR.Tests.TestSupport
+{
+    internal static class TestImageFactory
+    {
+        public static Bitmap CreateSolidBitmap(int width, int height, Color color)
+        {
+            var bitmap = new Bitmap(width, height);
+            using (var graphics = Graphics.FromImage(bitmap))
+            {
+                graphics.Clear(color);
+            }
+
+            return bitmap;
+        }
+    }
+}

--- a/Tests/TestSupport/TestImageFactory.cs
+++ b/Tests/TestSupport/TestImageFactory.cs
@@ -2,6 +2,9 @@ using System.Drawing;
 
 namespace TrOCR.Tests.TestSupport
 {
+    /// <summary>
+    /// 测试辅助工厂，生成指定颜色的纯色位图用于图像相关单元测试的像素级断言。
+    /// </summary>
     internal static class TestImageFactory
     {
         public static Bitmap CreateSolidBitmap(int width, int height, Color color)

--- a/Tests/TrOCR.Tests.csproj
+++ b/Tests/TrOCR.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net481</TargetFramework>
+    <LangVersion>9.0</LangVersion>
+    <IsPackable>false</IsPackable>
+    <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Windows.Forms" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\Utilities\ImageHelper.cs" Link="Production\Utilities\ImageHelper.cs" />
+    <Compile Include="..\Utilities\OwnedImage.cs" Link="Production\Utilities\OwnedImage.cs" />
+    <Compile Include="..\Utilities\ClipboardHelper.cs" Link="Production\Utilities\ClipboardHelper.cs" />
+    <Compile Include="..\Forms\Dialogs\FmScreenPaste.cs" Link="Production\Forms\Dialogs\FmScreenPaste.cs" />
+    <Compile Include="..\Forms\Dialogs\FmScreenPaste.Designer.cs" Link="Production\Forms\Dialogs\FmScreenPaste.Designer.cs" />
+  </ItemGroup>
+</Project>

--- a/TrOCR.csproj
+++ b/TrOCR.csproj
@@ -258,13 +258,16 @@
       <DependentUpon>FmTempTranslate.cs</DependentUpon>
     </Compile>
     <Compile Include="Services\Translation\BaiduTranslator2Helper.cs" />
+    <Compile Include="Utilities\ClipboardHelper.cs" />
     <Compile Include="Utilities\CommonHelper.cs" />
     <Compile Include="Utilities\ExcelHelper.cs" />
     <Compile Include="Utilities\HanzToPinyin.cs" />
     <Compile Include="Utilities\HelpRepaint.cs" />
     <Compile Include="Utilities\HelpWin32.cs" />
     <Compile Include="Utilities\HttpHelper.cs" />
+    <Compile Include="Utilities\ImageHelper.cs" />
     <Compile Include="Utilities\IniHelper.cs" />
+    <Compile Include="Utilities\OwnedImage.cs" />
     <Compile Include="Models\AIModels.cs" />
     <Compile Include="Utilities\NetworkInitializer.cs" />
     <Compile Include="Services\OCR\OcrHelper.cs" />

--- a/TrOCR.sln
+++ b/TrOCR.sln
@@ -1,9 +1,13 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
-VisualStudioVersion = 17.14.36401.2 d17.14
+VisualStudioVersion = 17.14.36401.2
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TrOCR", "TrOCR.csproj", "{B130A49B-6676-465D-BAD4-B83666DFFA44}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{0AB3BF05-4346-4AA6-1389-037BE0695223}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TrOCR.Tests", "Tests\TrOCR.Tests.csproj", "{B8C62AAF-FB5A-4DA5-B84D-57DC9EDE162C}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -33,9 +37,28 @@ Global
 		{B130A49B-6676-465D-BAD4-B83666DFFA44}.Release|x64.Build.0 = Release|x64
 		{B130A49B-6676-465D-BAD4-B83666DFFA44}.Release|x86.ActiveCfg = Release|x86
 		{B130A49B-6676-465D-BAD4-B83666DFFA44}.Release|x86.Build.0 = Release|x86
+		{B8C62AAF-FB5A-4DA5-B84D-57DC9EDE162C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B8C62AAF-FB5A-4DA5-B84D-57DC9EDE162C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B8C62AAF-FB5A-4DA5-B84D-57DC9EDE162C}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{B8C62AAF-FB5A-4DA5-B84D-57DC9EDE162C}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{B8C62AAF-FB5A-4DA5-B84D-57DC9EDE162C}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B8C62AAF-FB5A-4DA5-B84D-57DC9EDE162C}.Debug|x64.Build.0 = Debug|Any CPU
+		{B8C62AAF-FB5A-4DA5-B84D-57DC9EDE162C}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B8C62AAF-FB5A-4DA5-B84D-57DC9EDE162C}.Debug|x86.Build.0 = Debug|Any CPU
+		{B8C62AAF-FB5A-4DA5-B84D-57DC9EDE162C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B8C62AAF-FB5A-4DA5-B84D-57DC9EDE162C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B8C62AAF-FB5A-4DA5-B84D-57DC9EDE162C}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{B8C62AAF-FB5A-4DA5-B84D-57DC9EDE162C}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{B8C62AAF-FB5A-4DA5-B84D-57DC9EDE162C}.Release|x64.ActiveCfg = Release|Any CPU
+		{B8C62AAF-FB5A-4DA5-B84D-57DC9EDE162C}.Release|x64.Build.0 = Release|Any CPU
+		{B8C62AAF-FB5A-4DA5-B84D-57DC9EDE162C}.Release|x86.ActiveCfg = Release|Any CPU
+		{B8C62AAF-FB5A-4DA5-B84D-57DC9EDE162C}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{B8C62AAF-FB5A-4DA5-B84D-57DC9EDE162C} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {0D78471A-2E8B-4745-9404-B8AFFC757936}

--- a/Utilities/ClipboardHelper.cs
+++ b/Utilities/ClipboardHelper.cs
@@ -1,0 +1,148 @@
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Windows.Forms;
+
+namespace TrOCR.Helper
+{
+    public static class ClipboardHelper
+    {
+        private const int DefaultRetryTimes = 8;
+        private const int DefaultRetryDelayMs = 120;
+
+        [DllImport("user32.dll", SetLastError = true)]
+        private static extern IntPtr GetOpenClipboardWindow();
+
+        [DllImport("user32.dll", SetLastError = true)]
+        private static extern uint GetWindowThreadProcessId(IntPtr hWnd, out uint processId);
+
+        public static bool TrySetDataObject(object data, out string errorMessage)
+        {
+            errorMessage = null;
+            if (data == null)
+            {
+                return true;
+            }
+
+            try
+            {
+                Clipboard.SetDataObject(data, true, DefaultRetryTimes, DefaultRetryDelayMs);
+                return true;
+            }
+            catch (Exception ex) when (IsClipboardException(ex))
+            {
+                errorMessage = BuildClipboardErrorMessage(ex);
+                Debug.WriteLine(errorMessage);
+                return false;
+            }
+        }
+
+        public static bool TrySetData(string format, object data, out string errorMessage)
+        {
+            errorMessage = null;
+            if (string.IsNullOrEmpty(format) || data == null)
+            {
+                return true;
+            }
+
+            var dataObject = new DataObject();
+            dataObject.SetData(format, data);
+            return TrySetDataObject(dataObject, out errorMessage);
+        }
+
+        public static bool TryGetText(out string text, out string errorMessage)
+        {
+            text = null;
+            errorMessage = null;
+
+            Exception lastException = null;
+            for (var attempt = 0; attempt < DefaultRetryTimes; attempt++)
+            {
+                try
+                {
+                    if (!Clipboard.ContainsText())
+                    {
+                        return true;
+                    }
+
+                    text = Clipboard.GetText();
+                    return true;
+                }
+                catch (Exception ex) when (IsClipboardException(ex))
+                {
+                    lastException = ex;
+                    Thread.Sleep(DefaultRetryDelayMs);
+                }
+            }
+
+            errorMessage = BuildClipboardErrorMessage(lastException);
+            Debug.WriteLine(errorMessage);
+            return false;
+        }
+
+        public static bool TryClear(out string errorMessage)
+        {
+            errorMessage = null;
+
+            Exception lastException = null;
+            for (var attempt = 0; attempt < DefaultRetryTimes; attempt++)
+            {
+                try
+                {
+                    Clipboard.Clear();
+                    return true;
+                }
+                catch (Exception ex) when (IsClipboardException(ex))
+                {
+                    lastException = ex;
+                    Thread.Sleep(DefaultRetryDelayMs);
+                }
+            }
+
+            errorMessage = BuildClipboardErrorMessage(lastException);
+            Debug.WriteLine(errorMessage);
+            return false;
+        }
+
+        public static string GetOpenClipboardOwnerDescription()
+        {
+            var handle = GetOpenClipboardWindow();
+            if (handle == IntPtr.Zero)
+            {
+                return "未能识别占用剪贴板的窗口";
+            }
+
+            GetWindowThreadProcessId(handle, out var processId);
+            if (processId == 0)
+            {
+                return $"剪贴板窗口句柄: 0x{handle.ToInt64():X}";
+            }
+
+            try
+            {
+                using (var process = Process.GetProcessById((int)processId))
+                {
+                    return $"占用进程: {process.ProcessName} (PID {processId})";
+                }
+            }
+            catch
+            {
+                return $"占用进程 PID: {processId}";
+            }
+        }
+
+        public static string BuildClipboardErrorMessage(Exception ex)
+        {
+            var detail = ex == null ? "未知错误" : ex.Message;
+            return "剪贴板暂时不可用，" + GetOpenClipboardOwnerDescription() + "。原始错误: " + detail;
+        }
+
+        private static bool IsClipboardException(Exception ex)
+        {
+            return ex is ExternalException ||
+                   ex is ThreadStateException ||
+                   ex is InvalidOperationException;
+        }
+    }
+}

--- a/Utilities/ImageHelper.cs
+++ b/Utilities/ImageHelper.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Drawing;
+using System.Drawing.Imaging;
+
+namespace TrOCR.Helper
+{
+    public static class ImageHelper
+    {
+        public static Bitmap CloneBitmap(Image source)
+        {
+            if (source == null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+
+            var clone = new Bitmap(source.Width, source.Height, PixelFormat.Format32bppArgb);
+            using (var graphics = Graphics.FromImage(clone))
+            {
+                graphics.DrawImage(source, 0, 0, source.Width, source.Height);
+            }
+
+            return clone;
+        }
+
+        public static bool IsUsable(Image image)
+        {
+            if (image == null)
+            {
+                return false;
+            }
+
+            try
+            {
+                return image.Width > 0 && image.Height > 0;
+            }
+            catch (ArgumentException)
+            {
+                return false;
+            }
+            catch (ObjectDisposedException)
+            {
+                return false;
+            }
+        }
+    }
+}

--- a/Utilities/OwnedImage.cs
+++ b/Utilities/OwnedImage.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Drawing;
+
+namespace TrOCR.Helper
+{
+    public sealed class OwnedImage : IDisposable
+    {
+        private Bitmap bitmap;
+
+        public OwnedImage(Image source)
+        {
+            bitmap = ImageHelper.CloneBitmap(source);
+        }
+
+        public Bitmap Bitmap
+        {
+            get
+            {
+                if (bitmap == null)
+                {
+                    throw new ObjectDisposedException(nameof(OwnedImage));
+                }
+
+                return bitmap;
+            }
+        }
+
+        public Size Size => Bitmap.Size;
+
+        public int Width => Bitmap.Width;
+
+        public int Height => Bitmap.Height;
+
+        public bool IsUsable => ImageHelper.IsUsable(bitmap);
+
+        public Bitmap CloneBitmap()
+        {
+            return ImageHelper.CloneBitmap(Bitmap);
+        }
+
+        public void Dispose()
+        {
+            var image = bitmap;
+            bitmap = null;
+            image?.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
## 根因

`FmScreenPaste` 直接引用调用方传入的 `Image` 对象作为 `BackgroundImage`。当主窗口执行下一次截图时调用 `image_screen?.Dispose()`，贴图窗口持有的 Image 底层 GDI+ 句柄随之失效。此后任何触发 `OnPaint` 的操作（拖到屏幕边缘、右键菜单）都会在 `Image.get_Width()` 抛出 `ArgumentException`，WinForms 渲染为红叉白框。

<img width="909" height="171" alt="image" src="https://github.com/user-attachments/assets/8e4df4f9-237d-48e4-900a-dd78d40b53c6" />

剪贴板锁定是独立的第二失败路径：远程桌面/Ditto 等占用剪贴板时，`Clipboard.SetImage()` 直接抛异常且无重试，贴图窗口无任何错误提示。

## 修复方法

1. **图像所有权隔离** — 贴图窗口在构造时通过 `OwnedImage` 克隆一份独立 Bitmap，不再共享调用方实例
2. **防御性绘制** — `OnPaint` 检查图像有效性 + try-catch，失败时优雅关闭而非红叉
3. **安全剪贴板操作** — 新增 `ClipboardHelper`（重试 + 锁持有者诊断），所有剪贴板写入/读取统一走此路径

## 文件修改摘要

| 文件                                      | 改动                                                                                                                                                                                                         |
| ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
| `Utilities/ImageHelper.cs`                | **新增** — `CloneBitmap()` 深拷贝、`IsUsable()` 有效性检测                                                                                                                                                   |
| `Utilities/OwnedImage.cs`                 | **新增** — 持有独立 Bitmap 副本的 IDisposable 包装器                                                                                                                                                         |
| `Utilities/ClipboardHelper.cs`            | **新增** — 带 8 次重试 + P/Invoke 诊断占用进程的剪贴板操作封装                                                                                                                                               |
| `Forms/Dialogs/FmScreenPaste.cs`          | 重写为使用 `OwnedImage`；`OnPaint` 添加异常保护；复制操作改用安全副本 + `ClipboardHelper`；保存操作添加错误处理并修复 PNG 过滤器 typo (`*.png)\|*.jpg` → `*.png)\|*.png`)；移除 `GC.Collect()`；统一关闭路径 |
| `Forms/Dialogs/FmScreenPaste.Designer.cs` | `Dispose` 中释放 `pasteImage`                                                                                                                                                                                |
| `Forms/Main/FmMain.Clipboard.cs`          | `SetClipboardWithLock`/`SetClipboardDataWithLock` 改用 `ClipboardHelper`；`GetTextFromClipboard` 改用安全读取+清除                                                                                           |
| `Forms/Main/FmMain.OCR.Core.cs`           | 截图模式 `Clipboard.SetImage` 替换为 `CloneBitmap` + `ClipboardHelper`，失败时显示用户提示而非静默崩溃                                                                                                       |
| `Forms/Main/FmMain.Tray.cs`               | 输入翻译的剪贴板读取改用 `ClipboardHelper.TryGetText`                                                                                                                                                        |
| `Forms/Main/FmMain.Translation.cs`        | 常规翻译流程的剪贴板读取改用安全方式                                                                                                                                                                         |
| `TrOCR.csproj`                            | 注册三个新 Utility 文件                                                                                                                                                                                      |

---

## 测试部分（分开commit的，如不需要可以删掉）

为贴图窗口图像失效修复（fix/screenpaste-clipboard-error 分支）补充自动化回归测试。
使用独立的 SDK-style NUnit 测试项目，通过链接少量生产文件实现测试隔离，不引用主 WinExe 项目。

## 修改

1. Tests/TrOCR.Tests.csproj (新建)

   - SDK-style 项目，目标 net481 + PackageReference（NUnit 3.14, NUnit3TestAdapter 4.5, Microsoft.NET.Test.Sdk 17.11）
   - 通过 `<Compile Include="..\" Link="Production\...">` 链接 5 个生产文件
   - 引用 System.Drawing / System.Windows.Forms

2. Tests/Stubs/CommonHelperStub.cs (新建)

   - 测试专用 CommonHelper 替身，记录 toast 调用参数而非弹窗
   - 匹配生产签名 ShowHelpMsg(string) / ShowHelpMsg(string, uint)

3. Tests/TestSupport/TestImageFactory.cs (新建)

   - 确定性纯色 Bitmap 工厂，用于所有图像测试

4. Tests/ImageHelperTests.cs (新建, 4 tests)

   - CloneBitmap 源图 Dispose 后克隆仍可用（像素级验证 + DrawImage 验证）
   - CloneBitmap null 参数抛 ArgumentNullException
   - IsUsable 对已释放图像返回 false
   - IsUsable 对 null 返回 false

5. Tests/OwnedImageTests.cs (新建, 2 tests)

   - 构造后源图 Dispose，OwnedImage 内部 bitmap 保持独立可用
   - Dispose 后访问 Bitmap 属性抛 ObjectDisposedException

6. Tests/FmScreenPasteTests.cs (新建, 1 test)

   - 核心回归路径：源图 Dispose 后调用真实 OnPaint，验证窗口正常渲染拥有的副本
   - 使用 TestableFmScreenPaste 子类暴露 protected OnPaint

7. Tests/ClipboardHelperTests.cs (新建, 2 + 1 Explicit tests)

   - TrySetDataObject null 参数直接返回 true
   - BuildClipboardErrorMessage 包含中文诊断信息和原始异常
   - [Explicit] 剪贴板锁定集成测试：P/Invoke OpenClipboard 模拟占用，验证 TrySetDataObject 返回 false + 诊断信息

8. TrOCR.sln (修改)

   - 添加 Tests\TrOCR.Tests.csproj 项目条目

## Test Results

   - 9 passed, 0 failed, 1 skipped (Explicit)
   - x64 Debug build: OK
   - x86 Debug build: OK (existing PaddleOCR arch warning accepted)
