### PR TITLE
[FIX] 修复 bing2 翻译接口失效 + 优化 UI 设置页接口隐藏逻辑

### DIFF
--- a/Forms/Settings/FmSetting.Init.cs
+++ b/Forms/Settings/FmSetting.Init.cs
@@ -942,78 +942,14 @@ namespace TrOCR
 			var caiyun2Token = IniHelper.GetValue("Translate_Caiyun2", "Token");
 			textBox_Caiyun2_Token.Text = (caiyun2Token == "发生错误") ? "3975l6lr5pcbvidl6jl2" : caiyun2Token;
 
-			// 设置页的翻译接口可见性
-			Action<string, CheckBox, TabPage> setTranVisibility = (apiName, checkBox, tabPage) =>
+			// 设置页的接口可见性（翻译 + OCR 统一由元数据表驱动）
+			BuildInterfaceEntries();
+			foreach (var entry in _interfaceEntries)
 			{
-				string visibilityValue = IniHelper.GetValue("翻译接口显示", apiName);
-				bool isVisible;
-				if (apiName == "TencentInteractive" || apiName == "Caiyun" || apiName == "Volcano" || apiName == "Baidu2")
-				{
-					isVisible = visibilityValue != "发生错误" && Convert.ToBoolean(visibilityValue);
-				}
-				else
-				{
-					isVisible = visibilityValue == "发生错误" || Convert.ToBoolean(visibilityValue);
-				}
-				checkBox.Checked = isVisible;
-				if (!isVisible)
-				{
-					tabControl_Trans.TabPages.Remove(tabPage);
-				}
-			};
-
-			setTranVisibility("Google", checkBox_ShowGoogle, tabPage_Google);
-			setTranVisibility("Baidu", checkBox_ShowBaidu, tabPage_Baidu);
-			setTranVisibility("Tencent", checkBox_ShowTencent, tabPage_Tencent);
-			setTranVisibility("Bing", checkBox_ShowBing, tabPage_Bing);
-			setTranVisibility("Bing2", checkBox_ShowBing2, tabPage_Bing2);
-			setTranVisibility("Microsoft", checkBox_ShowMicrosoft, tabPage_Microsoft);
-			setTranVisibility("Yandex", checkBox_ShowYandex, tabPage_Yandex);
-			setTranVisibility("TencentInteractive", checkBox_ShowTencentInteractive, tabPage_TencentInteractive);
-			setTranVisibility("Caiyun", checkBox_ShowCaiyun, tabPage_Caiyun);
-			setTranVisibility("Volcano", checkBox_ShowVolcano, tabPage_Volcano);
-			setTranVisibility("Caiyun2", checkBox_ShowCaiyun2, tabPage_Caiyun2);
-			setTranVisibility("Baidu2", checkBox_ShowBaidu2, tabPage_Baidu2);
-
-			// 设置页的OCR接口可见性
-			Action<string, CheckBox, TabPage> setOcrVisibility = (apiName, checkBox, tabPage) =>
-			{
-				string visibilityValue = IniHelper.GetValue("Ocr接口显示", apiName);
-				bool isVisible;
-				if (apiName == "Baimiao")
-				{
-					isVisible = visibilityValue != "发生错误" && Convert.ToBoolean(visibilityValue);
-				}
-				else
-				{
-					isVisible = visibilityValue == "发生错误" || Convert.ToBoolean(visibilityValue);
-				}
-				checkBox.Checked = isVisible;
-				if (!isVisible && tabPage != null)
-				{
-					tabControl2.TabPages.Remove(tabPage);
-				}
-			};
-			//此处百度和腾讯的接口隐藏后移除密钥设置页的标签页功能已失效，暂时就这样吧
-			setOcrVisibility("Baidu", checkBox_ShowOcrBaidu, inPage_百度接口);
-			setOcrVisibility("BaiduAccurate", checkBox_ShowOcrBaiduAccurate, inPage_百度高精度接口);
-			setOcrVisibility("Tencent", checkBox_ShowOcrTencent, inPage_腾讯接口);
-			setOcrVisibility("TencentAccurate", checkBox_ShowOcrTencentAccurate, inPage_腾讯高精度接口);
-			setOcrVisibility("Baimiao", checkBox_ShowOcrBaimiao, tabPage_白描接口);
-			setOcrVisibility("Sougou", checkBox_ShowOcrSougou, null);
-			setOcrVisibility("Youdao", checkBox_ShowOcrYoudao, null);
-			setOcrVisibility("WeChat", checkBox_ShowOcrWeChat, null);
-			setOcrVisibility("Mathfuntion", checkBox_ShowOcrMathfuntion, null);
-			setOcrVisibility("Table", checkBox_ShowOcrTable, null);
-			setOcrVisibility("Shupai", checkBox_ShowOcrShupai, null);
-			setOcrVisibility("TableBaidu", checkBox_ShowOcrTableBaidu, null);
-			setOcrVisibility("TableAli", checkBox_ShowOcrTableAli, null);
-			setOcrVisibility("ShupaiLR", checkBox_ShowOcrShupaiLR, null);
-			setOcrVisibility("ShupaiRL", checkBox_ShowOcrShupaiRL, null);
-			setOcrVisibility("TencentTable", checkBox_ShowOcrTableTencent, null);
-			setOcrVisibility("PaddleOCR", checkBox_ShowOcrPaddleOCR, inPage_PaddleOCR);
-			setOcrVisibility("PaddleOCR2", checkBox_ShowOcrPaddleOCR2, inPage_PaddleOCR2);
-			setOcrVisibility("RapidOCR", checkBox_ShowOcrRapidOCR, inPage_RapidOCR);
+				string visibilityValue = IniHelper.GetValue(entry.Section, entry.Key);
+				entry.CheckBox.Checked = InterfaceVisibility.ResolveInitialVisibility(visibilityValue, entry.DefaultVisible);
+			}
+			RefreshInterfaceTabPages();
 
 			// 读取OCR模型配置
 			ReadOcrModelConfigs();
@@ -1136,37 +1072,10 @@ namespace TrOCR
 			AdjustPageSize(tab_标签, EventArgs.Empty);
 
 			// 为所有接口可见性复选框附加事件处理程序
-			checkBox_ShowOcrBaidu.CheckedChanged += ApiVisibility_CheckedChanged;
-			checkBox_ShowOcrBaiduAccurate.CheckedChanged += ApiVisibility_CheckedChanged;
-			checkBox_ShowOcrTencent.CheckedChanged += ApiVisibility_CheckedChanged;
-			checkBox_ShowOcrTencentAccurate.CheckedChanged += ApiVisibility_CheckedChanged;
-			checkBox_ShowOcrBaimiao.CheckedChanged += ApiVisibility_CheckedChanged;
-			checkBox_ShowOcrSougou.CheckedChanged += ApiVisibility_CheckedChanged;
-			checkBox_ShowOcrYoudao.CheckedChanged += ApiVisibility_CheckedChanged;
-			checkBox_ShowOcrWeChat.CheckedChanged += ApiVisibility_CheckedChanged;
-			checkBox_ShowOcrMathfuntion.CheckedChanged += ApiVisibility_CheckedChanged;
-			checkBox_ShowOcrTable.CheckedChanged += ApiVisibility_CheckedChanged;
-			checkBox_ShowOcrShupai.CheckedChanged += ApiVisibility_CheckedChanged;
-			checkBox_ShowOcrTableBaidu.CheckedChanged += ApiVisibility_CheckedChanged;
-			checkBox_ShowOcrTableAli.CheckedChanged += ApiVisibility_CheckedChanged;
-			checkBox_ShowOcrShupaiLR.CheckedChanged += ApiVisibility_CheckedChanged;
-			checkBox_ShowOcrShupaiRL.CheckedChanged += ApiVisibility_CheckedChanged;
-			checkBox_ShowOcrTableTencent.CheckedChanged += ApiVisibility_CheckedChanged;
-			checkBox_ShowOcrPaddleOCR.CheckedChanged += ApiVisibility_CheckedChanged;
-			checkBox_ShowOcrPaddleOCR2.CheckedChanged += ApiVisibility_CheckedChanged;
-			checkBox_ShowOcrRapidOCR.CheckedChanged += ApiVisibility_CheckedChanged;
-			checkBox_ShowGoogle.CheckedChanged += ApiVisibility_CheckedChanged;
-			checkBox_ShowBaidu.CheckedChanged += ApiVisibility_CheckedChanged;
-			checkBox_ShowTencent.CheckedChanged += ApiVisibility_CheckedChanged;
-			checkBox_ShowBing.CheckedChanged += ApiVisibility_CheckedChanged;
-			checkBox_ShowBing2.CheckedChanged += ApiVisibility_CheckedChanged;
-			checkBox_ShowMicrosoft.CheckedChanged += ApiVisibility_CheckedChanged;
-			checkBox_ShowYandex.CheckedChanged += ApiVisibility_CheckedChanged;
-			checkBox_ShowTencentInteractive.CheckedChanged += ApiVisibility_CheckedChanged;
-			checkBox_ShowCaiyun.CheckedChanged += ApiVisibility_CheckedChanged;
-			checkBox_ShowVolcano.CheckedChanged += ApiVisibility_CheckedChanged;
-			checkBox_ShowCaiyun2.CheckedChanged += ApiVisibility_CheckedChanged;
-			checkBox_ShowBaidu2.CheckedChanged += ApiVisibility_CheckedChanged;
+			foreach (var entry in _interfaceEntries)
+			{
+				entry.CheckBox.CheckedChanged += ApiVisibility_CheckedChanged;
+			}
 
 			// 为OCR模型配置按钮添加事件处理程序
 			// PaddleOCR事件

--- a/Forms/Settings/FmSetting.InterfaceVisibility.cs
+++ b/Forms/Settings/FmSetting.InterfaceVisibility.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Windows.Forms;
+using TrOCR.Helper;
+
+namespace TrOCR
+{
+    /// <summary>
+    /// FmSetting 的 partial：接口显隐元数据表与刷新逻辑。
+    /// 决策由 InterfaceVisibility 纯函数承担，本文件只做控件增删执行。
+    /// </summary>
+    public sealed partial class FmSetting
+    {
+        /// <summary>
+        /// 单个接口的显隐元数据。
+        /// TabPage/ParentTabControl 为 null 表示该接口在设置页无对应 TabPage（只控主窗口右键菜单）。
+        /// </summary>
+        private struct InterfaceVisibilityEntry
+        {
+            public string Name;
+            public string Section;
+            public string Key;
+            public CheckBox CheckBox;
+            public TabPage TabPage;
+            public TabControl ParentTabControl;
+            public int OriginalIndex;
+            public bool DefaultVisible;
+            public string InUseSource;
+            public string[] InUseValues;
+        }
+
+        private InterfaceVisibilityEntry[] _interfaceEntries;
+
+        /// <summary>
+        /// 构建 31 条接口元数据表（翻译 12 + OCR 19）。
+        /// 必须在 InitializeComponent 之后调用（引用实例控件）。
+        /// 数据已与原绑定段/读取段/保存段/使用中检查四处硬编码逐条核对一致。
+        /// </summary>
+        private void BuildInterfaceEntries()
+        {
+            _interfaceEntries = new[]
+            {
+                // ===== 翻译接口（12）— 父容器 tabControl_Trans，使用中查 INI key "翻译接口" =====
+                Entry("Google",             "翻译接口显示", "Google",             checkBox_ShowGoogle,             tabPage_Google,             tabControl_Trans, 0,  true, "翻译接口", "谷歌"),
+                Entry("Baidu",              "翻译接口显示", "Baidu",              checkBox_ShowBaidu,              tabPage_Baidu,              tabControl_Trans, 1,  true, "翻译接口", "百度"),
+                Entry("Tencent",            "翻译接口显示", "Tencent",            checkBox_ShowTencent,            tabPage_Tencent,            tabControl_Trans, 2,  true, "翻译接口", "腾讯"),
+                Entry("Bing",               "翻译接口显示", "Bing",               checkBox_ShowBing,               tabPage_Bing,               tabControl_Trans, 3,  true, "翻译接口", "Bing"),
+                Entry("Bing2",              "翻译接口显示", "Bing2",              checkBox_ShowBing2,              tabPage_Bing2,              tabControl_Trans, 4,  true, "翻译接口", "Bing2"),
+                Entry("Microsoft",          "翻译接口显示", "Microsoft",          checkBox_ShowMicrosoft,          tabPage_Microsoft,          tabControl_Trans, 5,  true, "翻译接口", "Microsoft"),
+                Entry("Yandex",             "翻译接口显示", "Yandex",             checkBox_ShowYandex,             tabPage_Yandex,             tabControl_Trans, 6,  true, "翻译接口", "Yandex"),
+                Entry("TencentInteractive", "翻译接口显示", "TencentInteractive", checkBox_ShowTencentInteractive, tabPage_TencentInteractive, tabControl_Trans, 7,  false, "翻译接口", "腾讯交互翻译"),
+                Entry("Caiyun",             "翻译接口显示", "Caiyun",             checkBox_ShowCaiyun,             tabPage_Caiyun,             tabControl_Trans, 8,  false, "翻译接口", "彩云小译"),
+                Entry("Volcano",            "翻译接口显示", "Volcano",            checkBox_ShowVolcano,            tabPage_Volcano,            tabControl_Trans, 9,  false, "翻译接口", "火山翻译"),
+                Entry("Caiyun2",            "翻译接口显示", "Caiyun2",            checkBox_ShowCaiyun2,            tabPage_Caiyun2,            tabControl_Trans, 10, true, "翻译接口", "彩云小译2"),
+                Entry("Baidu2",             "翻译接口显示", "Baidu2",             checkBox_ShowBaidu2,             tabPage_Baidu2,             tabControl_Trans, 11, false, "翻译接口", "百度2"),
+
+                // ===== OCR 接口（19）— 使用中查 INI key "接口" =====
+                // 嵌套 TabControl：百度（修复 Q1——原代码错误地传给 tabControl2，导致 Remove 空操作）
+                Entry("Baidu",              "Ocr接口显示", "Baidu",              checkBox_ShowOcrBaidu,           inPage_百度接口,      tabControl_BaiduApiType, 0, true, "接口", "中英", "日语", "韩语"),
+                Entry("BaiduAccurate",      "Ocr接口显示", "BaiduAccurate",      checkBox_ShowOcrBaiduAccurate,   inPage_百度高精度接口, tabControl_BaiduApiType, 1, true, "接口", "百度-高精度"),
+                // 嵌套 TabControl：腾讯
+                Entry("Tencent",            "Ocr接口显示", "Tencent",            checkBox_ShowOcrTencent,         inPage_腾讯接口,      tabControl_TXApiType,    0, true, "接口", "腾讯"),
+                Entry("TencentAccurate",    "Ocr接口显示", "TencentAccurate",    checkBox_ShowOcrTencentAccurate, inPage_腾讯高精度接口, tabControl_TXApiType,    1, true, "接口", "腾讯-高精度"),
+                // tabControl2 直接子页（注意：inPage_PaddleOCR/RapidOCR 虽叫 inPage_ 但是 tabControl2 直接子页）
+                Entry("Baimiao",            "Ocr接口显示", "Baimiao",            checkBox_ShowOcrBaimiao,         tabPage_白描接口,     tabControl2,             2, false, "接口", "白描"),
+                Entry("PaddleOCR",          "Ocr接口显示", "PaddleOCR",          checkBox_ShowOcrPaddleOCR,       inPage_PaddleOCR,     tabControl2,             3, true, "接口", "PaddleOCR"),
+                Entry("PaddleOCR2",         "Ocr接口显示", "PaddleOCR2",         checkBox_ShowOcrPaddleOCR2,      inPage_PaddleOCR2,    tabControl2,             4, true, "接口", "PaddleOCR2"),
+                Entry("RapidOCR",           "Ocr接口显示", "RapidOCR",           checkBox_ShowOcrRapidOCR,        inPage_RapidOCR,      tabControl2,             5, true, "接口", "RapidOCR"),
+                // 无设置页（只控主窗口右键菜单显隐，TabPage/Parent 传 null）
+                Entry("Sougou",             "Ocr接口显示", "Sougou",            checkBox_ShowOcrSougou,          null, null, -1, true, "接口", "搜狗"),
+                Entry("Youdao",             "Ocr接口显示", "Youdao",            checkBox_ShowOcrYoudao,          null, null, -1, true, "接口", "有道"),
+                Entry("WeChat",             "Ocr接口显示", "WeChat",            checkBox_ShowOcrWeChat,          null, null, -1, true, "接口", "微信"),
+                Entry("Mathfuntion",        "Ocr接口显示", "Mathfuntion",       checkBox_ShowOcrMathfuntion,     null, null, -1, true, "接口", "公式"),
+                Entry("Table",              "Ocr接口显示", "Table",             checkBox_ShowOcrTable,           null, null, -1, true, "接口", "百度表格", "阿里表格"),
+                Entry("Shupai",             "Ocr接口显示", "Shupai",            checkBox_ShowOcrShupai,          null, null, -1, true, "接口", "从左向右", "从右向左"),
+                Entry("TableBaidu",         "Ocr接口显示", "TableBaidu",        checkBox_ShowOcrTableBaidu,      null, null, -1, true, "接口", "百度表格"),
+                Entry("TableAli",           "Ocr接口显示", "TableAli",          checkBox_ShowOcrTableAli,        null, null, -1, true, "接口", "阿里表格"),
+                Entry("ShupaiLR",           "Ocr接口显示", "ShupaiLR",          checkBox_ShowOcrShupaiLR,        null, null, -1, true, "接口", "从左向右"),
+                Entry("ShupaiRL",           "Ocr接口显示", "ShupaiRL",          checkBox_ShowOcrShupaiRL,        null, null, -1, true, "接口", "从右向左"),
+                Entry("TencentTable",       "Ocr接口显示", "TencentTable",      checkBox_ShowOcrTableTencent,    null, null, -1, true, "接口", "腾讯表格"),
+            };
+        }
+
+        /// <summary>元数据条目构造辅助（params 简化 InUseValues 书写）</summary>
+        private static InterfaceVisibilityEntry Entry(
+            string name, string section, string key,
+            CheckBox checkBox, TabPage tabPage, TabControl parent, int originalIndex,
+            bool defaultVisible, string inUseSource, params string[] inUseValues)
+        {
+            return new InterfaceVisibilityEntry
+            {
+                Name = name,
+                Section = section,
+                Key = key,
+                CheckBox = checkBox,
+                TabPage = tabPage,
+                ParentTabControl = parent,
+                OriginalIndex = originalIndex,
+                DefaultVisible = defaultVisible,
+                InUseSource = inUseSource,
+                InUseValues = inUseValues
+            };
+        }
+
+        /// <summary>
+        /// 幂等刷新：按当前 CheckBox.Checked 状态，对每个有 TabPage 的条目
+        /// 决定 Insert/Remove/None，使设置页 TabPage 显隐与勾选状态一致。
+        /// 用 OriginalIndex 插回以保持顺序稳定。
+        /// </summary>
+        private void RefreshInterfaceTabPages()
+        {
+            if (_interfaceEntries == null) return;
+
+            foreach (var e in _interfaceEntries)
+            {
+                if (e.TabPage == null || e.ParentTabControl == null) continue;
+
+                bool currentlyInParent = e.ParentTabControl.TabPages.Contains(e.TabPage);
+                switch (InterfaceVisibility.ComputePageAction(e.CheckBox.Checked, currentlyInParent))
+                {
+                    case InterfaceVisibility.PageAction.Insert:
+                        e.ParentTabControl.TabPages.Insert(e.OriginalIndex, e.TabPage);
+                        break;
+                    case InterfaceVisibility.PageAction.Remove:
+                        e.ParentTabControl.TabPages.Remove(e.TabPage);
+                        break;
+                }
+            }
+        }
+    }
+}

--- a/Forms/Settings/FmSetting.Misc.cs
+++ b/Forms/Settings/FmSetting.Misc.cs
@@ -342,59 +342,38 @@ namespace TrOCR
 		/// </summary>
 		private void ApiVisibility_CheckedChanged(object sender, EventArgs e)
 		{
-		 CheckBox checkBox = sender as CheckBox;
-		 if (checkBox == null || checkBox.Checked)
-		 {
-		  return; // 只在取消勾选时处理
-		 }
+			CheckBox checkBox = sender as CheckBox;
+			if (checkBox == null) return;
 
-		 string currentOcrApi = IniHelper.GetValue("配置", "接口");
-		 string currentTranslateApi = IniHelper.GetValue("配置", "翻译接口");
+			if (_interfaceEntries == null) return;
 
-		 bool isInUse = false;
+			// 使用中检查只在取消勾选时做（勾选是恢复显示，无需保护）
+			if (!checkBox.Checked)
+			{
+				foreach (var entry in _interfaceEntries)
+				{
+					if (!ReferenceEquals(entry.CheckBox, checkBox)) continue;
 
-		 // OCR API 检查
-		 if (checkBox == checkBox_ShowOcrBaidu && (new[] { "中英", "日语", "韩语" }).Contains(currentOcrApi)) isInUse = true;
-		 else if (checkBox == checkBox_ShowOcrBaiduAccurate && currentOcrApi == "百度-高精度") isInUse = true;
-		 else if (checkBox == checkBox_ShowOcrTencent && currentOcrApi == "腾讯") isInUse = true;
-		 else if (checkBox == checkBox_ShowOcrTencentAccurate && currentOcrApi == "腾讯-高精度") isInUse = true;
-		 else if (checkBox == checkBox_ShowOcrBaimiao && currentOcrApi == "白描") isInUse = true;
-		 else if (checkBox == checkBox_ShowOcrSougou && currentOcrApi == "搜狗") isInUse = true;
-		 else if (checkBox == checkBox_ShowOcrYoudao && currentOcrApi == "有道") isInUse = true;
-		 else if (checkBox == checkBox_ShowOcrWeChat && currentOcrApi == "微信") isInUse = true;
-		 else if (checkBox == checkBox_ShowOcrMathfuntion && currentOcrApi == "公式") isInUse = true;
-		 else if (checkBox == checkBox_ShowOcrTable && (new[] { "百度表格", "阿里表格" }).Contains(currentOcrApi)) isInUse = true;
-		 else if (checkBox == checkBox_ShowOcrShupai && (new[] { "从左向右", "从右向左" }).Contains(currentOcrApi)) isInUse = true;
-		 else if (checkBox == checkBox_ShowOcrTableBaidu && currentOcrApi == "百度表格") isInUse = true;
-		 else if (checkBox == checkBox_ShowOcrTableAli && currentOcrApi == "阿里表格") isInUse = true;
-		 else if (checkBox == checkBox_ShowOcrTableTencent && currentOcrApi == "腾讯表格") isInUse = true;
-		 else if (checkBox == checkBox_ShowOcrShupaiLR && currentOcrApi == "从左向右") isInUse = true;
-		 else if (checkBox == checkBox_ShowOcrShupaiRL && currentOcrApi == "从右向左") isInUse = true;
-		 else if (checkBox == checkBox_ShowOcrPaddleOCR && currentOcrApi == "PaddleOCR") isInUse = true;
-		 else if (checkBox == checkBox_ShowOcrPaddleOCR2 && currentOcrApi == "PaddleOCR2") isInUse = true;
-		 else if (checkBox == checkBox_ShowOcrRapidOCR && currentOcrApi == "RapidOCR") isInUse = true;
-			// 翻译 API 检查
-			else if (checkBox == checkBox_ShowGoogle && currentTranslateApi == "谷歌") isInUse = true;
-			else if (checkBox == checkBox_ShowBaidu && currentTranslateApi == "百度") isInUse = true;
-			else if (checkBox == checkBox_ShowTencent && currentTranslateApi == "腾讯") isInUse = true;
-			else if (checkBox == checkBox_ShowBing && currentTranslateApi == "Bing") isInUse = true;
-			else if (checkBox == checkBox_ShowBing2 && currentTranslateApi == "Bing2") isInUse = true;
-			else if (checkBox == checkBox_ShowMicrosoft && currentTranslateApi == "Microsoft") isInUse = true;
-			else if (checkBox == checkBox_ShowYandex && currentTranslateApi == "Yandex") isInUse = true;
-			else if (checkBox == checkBox_ShowTencentInteractive && currentTranslateApi == "腾讯交互翻译") isInUse = true;
-			else if (checkBox == checkBox_ShowCaiyun && currentTranslateApi == "彩云小译") isInUse = true;
-			else if (checkBox == checkBox_ShowVolcano && currentTranslateApi == "火山翻译") isInUse = true;
-			else if (checkBox == checkBox_ShowCaiyun2 && currentTranslateApi == "彩云小译2") isInUse = true;
-			else if (checkBox == checkBox_ShowBaidu2 && currentTranslateApi == "百度2") isInUse = true;
-		//如果接口正在使用，弹出提示
-		 if (isInUse)
-		 {
-		  MessageBox.Show("该接口正在使用中，不能隐藏。", "提示", MessageBoxButtons.OK, MessageBoxIcon.None);
-		  // 重新勾选复选框，并临时移除事件处理程序以避免无限循环
-		  checkBox.CheckedChanged -= ApiVisibility_CheckedChanged;
-		  checkBox.Checked = true;
-		  checkBox.CheckedChanged += ApiVisibility_CheckedChanged;
-		 }
+					// 使用中检查：命中"当前接口"任一匹配值则阻止隐藏
+					if (entry.InUseValues != null && entry.InUseValues.Length > 0)
+					{
+						string currentApi = IniHelper.GetValue("配置", entry.InUseSource);
+						if (Array.IndexOf(entry.InUseValues, currentApi) >= 0)
+						{
+							MessageBox.Show("该接口正在使用中，不能隐藏。", "提示", MessageBoxButtons.OK, MessageBoxIcon.None);
+							// 重新勾选复选框，临时移除事件处理程序以避免无限循环
+							checkBox.CheckedChanged -= ApiVisibility_CheckedChanged;
+							checkBox.Checked = true;
+							checkBox.CheckedChanged += ApiVisibility_CheckedChanged;
+							return; // 强制勾回，不刷新
+						}
+					}
+					break; // 命中触发者且未在用，跳出检查，落到下方刷新
+				}
+			}
+
+			// 同步显隐到对应 tab（勾选恢复 / 取消勾选移除，均实时刷新）
+			RefreshInterfaceTabPages();
 		}
     }
 }

--- a/Forms/Settings/FmSetting.Save.cs
+++ b/Forms/Settings/FmSetting.Save.cs
@@ -193,40 +193,14 @@ namespace TrOCR
             IniHelper.SetValue("Translate_Caiyun2", "Target", textBox_Caiyun2_Target.Text);
             IniHelper.SetValue("Translate_Caiyun2", "Token", textBox_Caiyun2_Token.Text);
 
-            // 保存翻译接口显示设置
-            IniHelper.SetValue("翻译接口显示", "Google", checkBox_ShowGoogle.Checked.ToString());
-            IniHelper.SetValue("翻译接口显示", "Baidu", checkBox_ShowBaidu.Checked.ToString());
-            IniHelper.SetValue("翻译接口显示", "Tencent", checkBox_ShowTencent.Checked.ToString());
-            IniHelper.SetValue("翻译接口显示", "Bing", checkBox_ShowBing.Checked.ToString());
-            IniHelper.SetValue("翻译接口显示", "Bing2", checkBox_ShowBing2.Checked.ToString());
-            IniHelper.SetValue("翻译接口显示", "Microsoft", checkBox_ShowMicrosoft.Checked.ToString());
-            IniHelper.SetValue("翻译接口显示", "Yandex", checkBox_ShowYandex.Checked.ToString());
-            IniHelper.SetValue("翻译接口显示", "TencentInteractive", checkBox_ShowTencentInteractive.Checked.ToString());
-            IniHelper.SetValue("翻译接口显示", "Caiyun", checkBox_ShowCaiyun.Checked.ToString());
-            IniHelper.SetValue("翻译接口显示", "Volcano", checkBox_ShowVolcano.Checked.ToString());
-            IniHelper.SetValue("翻译接口显示", "Caiyun2", checkBox_ShowCaiyun2.Checked.ToString());
-            IniHelper.SetValue("翻译接口显示", "Baidu2", checkBox_ShowBaidu2.Checked.ToString());
-
-            // 保存OCR接口显示设置
-            IniHelper.SetValue("Ocr接口显示", "Baidu", checkBox_ShowOcrBaidu.Checked.ToString());
-            IniHelper.SetValue("Ocr接口显示", "BaiduAccurate", checkBox_ShowOcrBaiduAccurate.Checked.ToString());
-            IniHelper.SetValue("Ocr接口显示", "Tencent", checkBox_ShowOcrTencent.Checked.ToString());
-            IniHelper.SetValue("Ocr接口显示", "TencentAccurate", checkBox_ShowOcrTencentAccurate.Checked.ToString());
-            IniHelper.SetValue("Ocr接口显示", "Baimiao", checkBox_ShowOcrBaimiao.Checked.ToString());
-            IniHelper.SetValue("Ocr接口显示", "Sougou", checkBox_ShowOcrSougou.Checked.ToString());
-            IniHelper.SetValue("Ocr接口显示", "Youdao", checkBox_ShowOcrYoudao.Checked.ToString());
-            IniHelper.SetValue("Ocr接口显示", "WeChat", checkBox_ShowOcrWeChat.Checked.ToString());
-            IniHelper.SetValue("Ocr接口显示", "Mathfuntion", checkBox_ShowOcrMathfuntion.Checked.ToString());
-            IniHelper.SetValue("Ocr接口显示", "Table", checkBox_ShowOcrTable.Checked.ToString());
-            IniHelper.SetValue("Ocr接口显示", "Shupai", checkBox_ShowOcrShupai.Checked.ToString());
-            IniHelper.SetValue("Ocr接口显示", "TableBaidu", checkBox_ShowOcrTableBaidu.Checked.ToString());
-            IniHelper.SetValue("Ocr接口显示", "TableAli", checkBox_ShowOcrTableAli.Checked.ToString());
-            IniHelper.SetValue("Ocr接口显示", "ShupaiLR", checkBox_ShowOcrShupaiLR.Checked.ToString());
-            IniHelper.SetValue("Ocr接口显示", "ShupaiRL", checkBox_ShowOcrShupaiRL.Checked.ToString());
-            IniHelper.SetValue("Ocr接口显示", "TencentTable", checkBox_ShowOcrTableTencent.Checked.ToString());
-            IniHelper.SetValue("Ocr接口显示", "PaddleOCR", checkBox_ShowOcrPaddleOCR.Checked.ToString());
-            IniHelper.SetValue("Ocr接口显示", "PaddleOCR2", checkBox_ShowOcrPaddleOCR2.Checked.ToString());
-            IniHelper.SetValue("Ocr接口显示", "RapidOCR", checkBox_ShowOcrRapidOCR.Checked.ToString());
+            // 保存接口显示设置（翻译 + OCR）
+            if (_interfaceEntries != null)
+            {
+                foreach (var entry in _interfaceEntries)
+                {
+                    IniHelper.SetValue(entry.Section, entry.Key, entry.CheckBox.Checked.ToString());
+                }
+            }
 
             // 保存OCR模型配置
             // PaddleOCR配置

--- a/Forms/Settings/InterfaceVisibility.cs
+++ b/Forms/Settings/InterfaceVisibility.cs
@@ -1,0 +1,43 @@
+using System;
+
+namespace TrOCR.Helper
+{
+    /// <summary>
+    /// 接口显隐的纯决策逻辑。
+    /// 决策与执行分离：本类只决定"该做什么动作"，
+    /// 控件增删由 FmSetting.RefreshInterfaceTabPages 执行。
+    /// </summary>
+    public static class InterfaceVisibility
+    {
+        /// <summary>TabPage 增删动作</summary>
+        public enum PageAction
+        {
+            None,
+            Insert,
+            Remove
+        }
+
+        /// <summary>
+        /// 根据"期望可见"与"当前是否在父容器中"决定增删动作。
+        /// 期望可见但不在 → Insert；期望不可见但在 → Remove；其余 → None。
+        /// </summary>
+        public static PageAction ComputePageAction(bool desiredVisible, bool currentlyInParent)
+        {
+            if (desiredVisible && !currentlyInParent) return PageAction.Insert;
+            if (!desiredVisible && currentlyInParent) return PageAction.Remove;
+            return PageAction.None;
+        }
+
+        /// <summary>
+        /// 解析 INI 值为初始可见性。
+        /// IniHelper 以 "发生错误" 表示键缺失，此时取 defaultVisible；
+        /// 畸形值（非 True/False）同样兜底取 defaultVisible，与项目其它读取模板一致。
+        /// </summary>
+        public static bool ResolveInitialVisibility(string iniValue, bool defaultVisible)
+        {
+            if (iniValue == "发生错误") return defaultVisible;
+            try { return Convert.ToBoolean(iniValue); }
+            catch { return defaultVisible; }
+        }
+    }
+}

--- a/Services/Translation/BingTranslator2.cs
+++ b/Services/Translation/BingTranslator2.cs
@@ -121,6 +121,40 @@ namespace TrOCR.Helper
         }
 
         /// <summary>
+        /// 构造 translatetext 端点请求体：JSON 字符串数组 ["text"]。
+        /// 新端点要求字符串数组，旧端点的对象数组 [{Text:""}] 已被拒绝(400)。
+        /// </summary>
+        public static string BuildRequestBody(string text)
+        {
+            return Newtonsoft.Json.JsonConvert.SerializeObject(new[] { text });
+        }
+
+        /// <summary>
+        /// 解析 translatetext 端点响应，返回译文文本；任何异常或非预期结构返回空串。
+        /// 响应结构与旧 Azure v3 同构：[{"translations":[{"text":"...","to":"..."}]}]。
+        /// </summary>
+        public static string ParseResponse(string json)
+        {
+            try
+            {
+                var result = JArray.Parse(json);
+                if (result.Count > 0 && result[0]["translations"] != null)
+                {
+                    var translations = result[0]["translations"] as JArray;
+                    if (translations != null && translations.Count > 0)
+                    {
+                        return translations[0]["text"]?.ToString()?.Trim() ?? string.Empty;
+                    }
+                }
+            }
+            catch
+            {
+                // 解析失败返回空串，由调用方作失败处理（与原内联解析的容错语义一致）
+            }
+            return string.Empty;
+        }
+
+        /// <summary>
         /// 翻译文本
         /// </summary>
         public static async Task<string> TranslateAsync(string text, string fromLanguage, string toLanguage)

--- a/Services/Translation/BingTranslator2.cs
+++ b/Services/Translation/BingTranslator2.cs
@@ -13,8 +13,7 @@ namespace TrOCR.Helper
     public static class BingTranslator2
     {
         private static readonly HttpClient HttpClient;
-        private static readonly string AuthUrl = "https://edge.microsoft.com/translate/auth";
-        private static readonly string TranslateUrl = "https://api-edge.cognitive.microsofttranslator.com/translate";
+        private static readonly string TranslateUrl = "https://edge.microsoft.com/translate/translatetext";
         // 语言映射表
         private static readonly Dictionary<string, string> LanguageMap = new Dictionary<string, string>
         {
@@ -91,36 +90,6 @@ namespace TrOCR.Helper
         }
 
         /// <summary>
-        /// 获取认证Token
-        /// </summary>
-        private static async Task<string> GetAuthTokenAsync()
-        {
-            try
-            {
-                using (var request = new HttpRequestMessage(HttpMethod.Get, AuthUrl))
-                {
-                    request.Headers.TryAddWithoutValidation("User-Agent",
-                        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36 Edg/113.0.1774.42");
-
-                    request.Headers.TryAddWithoutValidation("Accept", "*/*");
-
-                    using (var response = await HttpClient.SendAsync(request).ConfigureAwait(false))
-                    {
-                        if (response.IsSuccessStatusCode)
-                        {
-                            return await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-                        }
-                    }
-                }
-            }
-            catch (Exception ex)
-            {
-                System.Diagnostics.Debug.WriteLine($"获取Token失败: {ex.Message}");
-            }
-            return null;
-        }
-
-        /// <summary>
         /// 构造 translatetext 端点请求体：JSON 字符串数组 ["text"]。
         /// 新端点要求字符串数组，旧端点的对象数组 [{Text:""}] 已被拒绝(400)。
         /// </summary>
@@ -130,32 +99,28 @@ namespace TrOCR.Helper
         }
 
         /// <summary>
-        /// 解析 translatetext 端点响应，返回译文文本；任何异常或非预期结构返回空串。
+        /// 解析 translatetext 端点响应，返回译文文本；translations 缺失/为空返回空串。
         /// 响应结构与旧 Azure v3 同构：[{"translations":[{"text":"...","to":"..."}]}]。
+        /// 畸形 JSON（非预期 body）抛 JArray 解析异常，由调用方 TranslateAsync 的 catch
+        /// 统一处理为「翻译失败: …」——与迁移前内联解析语义一致，保留可诊断性。
         /// </summary>
         public static string ParseResponse(string json)
         {
-            try
+            var result = JArray.Parse(json);
+            if (result.Count > 0 && result[0]["translations"] != null)
             {
-                var result = JArray.Parse(json);
-                if (result.Count > 0 && result[0]["translations"] != null)
+                var translations = result[0]["translations"] as JArray;
+                if (translations != null && translations.Count > 0)
                 {
-                    var translations = result[0]["translations"] as JArray;
-                    if (translations != null && translations.Count > 0)
-                    {
-                        return translations[0]["text"]?.ToString()?.Trim() ?? string.Empty;
-                    }
+                    return translations[0]["text"]?.ToString()?.Trim() ?? string.Empty;
                 }
-            }
-            catch
-            {
-                // 解析失败返回空串，由调用方作失败处理（与原内联解析的容错语义一致）
             }
             return string.Empty;
         }
 
         /// <summary>
-        /// 翻译文本
+        /// 翻译文本（使用 Microsoft Edge translatetext 免鉴权端点）。
+        /// 错误以字符串形式返回（与项目其它翻译 provider 一致），调用方原样显示。
         /// </summary>
         public static async Task<string> TranslateAsync(string text, string fromLanguage, string toLanguage)
         {
@@ -164,78 +129,27 @@ namespace TrOCR.Helper
 
             try
             {
-                string token = null;
-                for (int i = 0; i < 3; i++) // 最多尝试3次
-                {
-                    // 获取认证Token
-                    token = await GetAuthTokenAsync().ConfigureAwait(false);
-                    if (!string.IsNullOrEmpty(token))
-                    {
-                        break; // 成功获取Token，跳出循环
-                    }
-                    if (i < 2) // 如果不是最后一次尝试，则等待
-                    {
-                        await Task.Delay(200).ConfigureAwait(false);
-                    }
-                }
-                
-                if (string.IsNullOrEmpty(token))
-                {
-                    return "获取认证Token失败";
-                }
-
-                // 转换语言代码
+                // 转换语言代码：auto/空 → "" 触发服务端自动检测
                 var from = ConvertToMicrosoftLangCode(fromLanguage);
                 var to = ConvertToMicrosoftLangCode(toLanguage);
 
-                // 构建请求URL
-                var url = $"{TranslateUrl}?api-version=3.0&from={from}&to={to}&includeSentenceLength=true";
+                // 新免鉴权端点：无需 token；query 参数 from(空=自动检测)/to/isEnterpriseClient
+                var url = $"{TranslateUrl}?from={from}&to={to}&isEnterpriseClient=false";
 
                 using (var request = new HttpRequestMessage(HttpMethod.Post, url))
                 {
-                    // 设置请求头
-                    request.Headers.TryAddWithoutValidation("Accept", "*/*");
-                    request.Headers.TryAddWithoutValidation("Accept-Language", "zh-TW,zh;q=0.9,ja;q=0.8,zh-CN;q=0.7,en-US;q=0.6,en;q=0.5");
-                    request.Headers.TryAddWithoutValidation("Authorization", $"Bearer {token}");
-                    request.Headers.TryAddWithoutValidation("Cache-Control", "no-cache");
-                    request.Headers.TryAddWithoutValidation("Pragma", "no-cache");
-                    request.Headers.TryAddWithoutValidation("Sec-Ch-Ua", "\"Microsoft Edge\";v=\"113\", \"Chromium\";v=\"113\", \"Not-A.Brand\";v=\"24\"");
-                    request.Headers.TryAddWithoutValidation("Sec-Ch-Ua-Mobile", "?0");
-                    request.Headers.TryAddWithoutValidation("Sec-Ch-Ua-Platform", "\"Windows\"");
-                    request.Headers.TryAddWithoutValidation("Sec-Fetch-Dest", "empty");
-                    request.Headers.TryAddWithoutValidation("Sec-Fetch-Mode", "cors");
-                    request.Headers.TryAddWithoutValidation("Sec-Fetch-Site", "cross-site");
-                    request.Headers.TryAddWithoutValidation("Referer", "https://appsumo.com/");
-                    request.Headers.TryAddWithoutValidation("Referrer-Policy", "strict-origin-when-cross-origin");
-                    request.Headers.TryAddWithoutValidation("User-Agent",
-                        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36 Edg/113.0.1774.42");
-
-                    // 设置请求体
-                    var bodyArray = new[] { new { Text = text } };
-                    var json = Newtonsoft.Json.JsonConvert.SerializeObject(bodyArray);
-                    // request.Content = new StringContent(json, Encoding.UTF8, "application/json");
-                    request.Content = new StringContent(json, Encoding.UTF8, "application/json");
+                    // body 为字符串数组 ["text"]（新端点要求）；Content-Type 由 StringContent 自动带。
+                    // User-Agent 由静态构造函数的全局 DefaultRequestHeaders 兜底，无需 request 级重复。
+                    request.Content = new StringContent(BuildRequestBody(text), Encoding.UTF8, "application/json");
 
                     using (var response = await HttpClient.SendAsync(request).ConfigureAwait(false))
                     {
                         if (response.IsSuccessStatusCode)
                         {
                             var responseString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-                            var result = JArray.Parse(responseString);
-
-                            if (result.Count > 0 && result[0]["translations"] != null)
-                            {
-                                var translations = result[0]["translations"] as JArray;
-                                if (translations != null && translations.Count > 0)
-                                {
-                                    return translations[0]["text"]?.ToString()?.Trim() ?? string.Empty;
-                                }
-                            }
+                            return ParseResponse(responseString);
                         }
-                        else
-                        {
-                            return $"翻译请求失败: HTTP {response.StatusCode}";
-                        }
+                        return $"翻译请求失败: HTTP {response.StatusCode}";
                     }
                 }
             }
@@ -243,8 +157,6 @@ namespace TrOCR.Helper
             {
                 return $"翻译失败: {ex.Message}";
             }
-
-            return string.Empty;
         }
 
         /// <summary>

--- a/Tests/BingTranslator2Tests.cs
+++ b/Tests/BingTranslator2Tests.cs
@@ -1,0 +1,68 @@
+using NUnit.Framework;
+using TrOCR.Helper;
+
+namespace TrOCR.Tests
+{
+    /// <summary>
+    /// BingTranslator2（bing2 免费翻译通道）纯函数单测。
+    /// 背景：bing2 已从旧 Edge auth 端点迁移到免鉴权 translatetext 端点。
+    /// 本测试只覆盖迁移抽出的两个纯函数（BuildRequestBody/ParseResponse），
+    /// 不含真实 HTTP smoke（后续统一规划免费 API 可用性测试时再加）。
+    /// </summary>
+    [TestFixture]
+    public class BingTranslator2Tests
+    {
+        /// <summary>
+        /// 普通文本应序列化为单元素字符串数组 JSON。
+        /// translatetext 端点要求 body 为 ["text"]，旧的对象数组 [{"Text":""}] 已被拒绝(400)。
+        /// </summary>
+        [Test]
+        public void BuildRequestBody_PlainText_ReturnsStringArrayJson()
+        {
+            Assert.That(BingTranslator2.BuildRequestBody("hello"), Is.EqualTo("[\"hello\"]"));
+        }
+
+        /// <summary>
+        /// 含双引号/反斜杠/中文/换行的文本必须经 JSON 正确转义，
+        /// 且反序列化回来仍为单元素数组——同时验证形状与转义。
+        /// </summary>
+        [Test]
+        public void BuildRequestBody_SpecialCharacters_ProperlyEscaped()
+        {
+            var json = BingTranslator2.BuildRequestBody("他说\"你好\"\n");
+            var roundTripped = Newtonsoft.Json.JsonConvert.DeserializeObject<string[]>(json);
+            Assert.That(roundTripped, Is.EqualTo(new[] { "他说\"你好\"\n" }));
+        }
+
+        /// <summary>
+        /// translatetext 成功响应(probe 实测样本)外层是数组：
+        /// [{"translations":[{"text":"...","to":"..."}]}]，解析 [0].translations[0].text 得译文。
+        /// </summary>
+        [Test]
+        public void ParseResponse_ValidSample_ReturnsTranslatedText()
+        {
+            var json = "[{\"translations\":[{\"text\":\"你好\",\"to\":\"zh-Hans\"}]}]";
+            Assert.That(BingTranslator2.ParseResponse(json), Is.EqualTo("你好"));
+        }
+
+        /// <summary>
+        /// translations 为空数组时返回空串，不崩溃。守护原 Count>0 判断。
+        /// </summary>
+        [Test]
+        public void ParseResponse_EmptyTranslations_ReturnsEmpty()
+        {
+            var json = "[{\"translations\":[]}]";
+            Assert.That(BingTranslator2.ParseResponse(json), Is.EqualTo(string.Empty));
+        }
+
+        /// <summary>
+        /// 缺 translations 字段时返回空串，不崩溃。守护原 null 判断。
+        /// </summary>
+        [Test]
+        public void ParseResponse_MissingTranslations_ReturnsEmpty()
+        {
+            var json = "[{}]";
+            Assert.That(BingTranslator2.ParseResponse(json), Is.EqualTo(string.Empty));
+        }
+    }
+}

--- a/Tests/InterfaceVisibilityTests.cs
+++ b/Tests/InterfaceVisibilityTests.cs
@@ -1,0 +1,63 @@
+using NUnit.Framework;
+using TrOCR.Helper;
+
+namespace TrOCR.Tests
+{
+    /// <summary>
+    /// InterfaceVisibility 纯函数单测。
+    /// 覆盖显隐动作决策（4 种组合）与初始可见性解析（正常/缺失/畸形 INI 值）。
+    /// 保护"决策逻辑写反"和"默认值抄错"两类重构失误。
+    /// </summary>
+    [TestFixture]
+    public class InterfaceVisibilityTests
+    {
+        // ---- ComputePageAction：4 种输入组合 ----
+
+        [Test]
+        public void ComputePageAction_VisibleButAbsent_ReturnsInsert()
+        {
+            Assert.That(InterfaceVisibility.ComputePageAction(true, false),
+                Is.EqualTo(InterfaceVisibility.PageAction.Insert));
+        }
+
+        [Test]
+        public void ComputePageAction_HiddenButPresent_ReturnsRemove()
+        {
+            Assert.That(InterfaceVisibility.ComputePageAction(false, true),
+                Is.EqualTo(InterfaceVisibility.PageAction.Remove));
+        }
+
+        [Test]
+        public void ComputePageAction_VisibleAndPresent_ReturnsNone()
+        {
+            Assert.That(InterfaceVisibility.ComputePageAction(true, true),
+                Is.EqualTo(InterfaceVisibility.PageAction.None));
+        }
+
+        [Test]
+        public void ComputePageAction_HiddenAndAbsent_ReturnsNone()
+        {
+            Assert.That(InterfaceVisibility.ComputePageAction(false, false),
+                Is.EqualTo(InterfaceVisibility.PageAction.None));
+        }
+
+        // ---- ResolveInitialVisibility ----
+
+        [TestCase("True",  true,  ExpectedResult = true)]
+        [TestCase("False", true,  ExpectedResult = false)]
+        [TestCase("True",  false, ExpectedResult = true)]
+        [TestCase("False", false, ExpectedResult = false)]
+        public bool ResolveInitialVisibility_NormalValue_Parses(string v, bool def)
+            => InterfaceVisibility.ResolveInitialVisibility(v, def);
+
+        [TestCase(true,  ExpectedResult = true)]  // 默认可见接口，INI 缺失 → 显示
+        [TestCase(false, ExpectedResult = false)] // 默认隐藏接口，INI 缺失 → 隐藏
+        public bool ResolveInitialVisibility_MissingKey_ReturnsDefault(bool def)
+            => InterfaceVisibility.ResolveInitialVisibility("发生错误", def);
+
+        [TestCase(true,  ExpectedResult = true)]  // 畸形值兜底默认
+        [TestCase(false, ExpectedResult = false)]
+        public bool ResolveInitialVisibility_MalformedValue_ReturnsDefault(bool def)
+            => InterfaceVisibility.ResolveInitialVisibility("garbage", def);
+    }
+}

--- a/Tests/TrOCR.Tests.csproj
+++ b/Tests/TrOCR.Tests.csproj
@@ -29,6 +29,7 @@
     <Compile Include="..\Services\ScreenCapture\ScreenCaptureRequest.cs" Link="Production\Services\ScreenCapture\ScreenCaptureRequest.cs" />
     <Compile Include="..\Forms\Dialogs\FmScreenPaste.cs" Link="Production\Forms\Dialogs\FmScreenPaste.cs" />
     <Compile Include="..\Forms\Dialogs\FmScreenPaste.Designer.cs" Link="Production\Forms\Dialogs\FmScreenPaste.Designer.cs" />
+    <Compile Include="..\Forms\Settings\InterfaceVisibility.cs" Link="Production\Forms\Settings\InterfaceVisibility.cs" />
     <Compile Include="..\Services\Translation\BingTranslator2.cs" Link="Production\Services\Translation\BingTranslator2.cs" />
   </ItemGroup>
 </Project>

--- a/Tests/TrOCR.Tests.csproj
+++ b/Tests/TrOCR.Tests.csproj
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <Reference Include="System.Drawing" />
+    <Reference Include="System.Net.Http" />
     <Reference Include="System.Windows.Forms" />
   </ItemGroup>
 
@@ -28,5 +29,6 @@
     <Compile Include="..\Services\ScreenCapture\ScreenCaptureRequest.cs" Link="Production\Services\ScreenCapture\ScreenCaptureRequest.cs" />
     <Compile Include="..\Forms\Dialogs\FmScreenPaste.cs" Link="Production\Forms\Dialogs\FmScreenPaste.cs" />
     <Compile Include="..\Forms\Dialogs\FmScreenPaste.Designer.cs" Link="Production\Forms\Dialogs\FmScreenPaste.Designer.cs" />
+    <Compile Include="..\Services\Translation\BingTranslator2.cs" Link="Production\Services\Translation\BingTranslator2.cs" />
   </ItemGroup>
 </Project>

--- a/TrOCR.csproj
+++ b/TrOCR.csproj
@@ -239,6 +239,10 @@
     <Compile Include="Forms\Settings\FmSetting.Misc.cs">
       <SubType>Form</SubType>
     </Compile>
+    <Compile Include="Forms\Settings\FmSetting.InterfaceVisibility.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="Forms\Settings\InterfaceVisibility.cs" />
     <Compile Include="Forms\Settings\FmSetting.Designer.cs">
       <DependentUpon>FmSetting.cs</DependentUpon>
     </Compile>


### PR DESCRIPTION
## 概述

本 PR 包含两项独立修复，主要修复 https://github.com/Topkill/tianruoocr/issues/36

1. **bing2 翻译接口迁移**：旧 Edge 翻译鉴权端点被微软下线（404），导致 bing2 免费翻译通道完全失效。迁移到新的免鉴权端点。
2. **设置页接口显隐逻辑优化**：在"显示的接口"tab 修改勾选后，对应翻译/密钥 tab 的接口页面现在实时刷新（原需关闭重开设置窗口生效）；同时统一了散落在多处的接口配置硬编码。

## 一、bing2 翻译接口迁移

### 背景

bing2 使用的是非官方 Edge 浏览器翻译端点。其旧鉴权流程依赖 `edge.microsoft.com/translate/auth` 获取 JWT token，该端点已被微软下线（返回 404），导致整个 bing2 通道失效。

### 接口调整详情

| 维度 | 修改前（已失效） | 修改后 |
|------|------------------|--------|
| 鉴权 | `GET edge.microsoft.com/translate/auth` 取 JWT token（已 404 下线） | 无鉴权 |
| 翻译端点 | `api-edge.cognitive.microsofttranslator.com/translate` | `edge.microsoft.com/translate/translatetext` |
| 请求参数 | `api-version=3.0&from=&to=&includeSentenceLength=true` | `from=&to=&isEnterpriseClient=false` |
| Authorization 头 | `Bearer {token}` | 已删除 |
| 请求体 | 对象数组 `[{"Text":"..."}]` | 字符串数组 `["..."]` |
| 响应解析路径 | `[0].translations[0].text` | 不变（响应结构同构） |

核心变化：**换端点 + 删除整个 token 鉴权流程 + 请求体由对象数组改为字符串数组**。迁移前测试新端点连续 20 次调用全部成功（英↔中各 10 次），无鉴权、无限流迹象。

### 修复效果

<img width="1054" height="639" alt="image" src="https://github.com/user-attachments/assets/354933e4-9ff5-466f-8b7e-b8e2ab903afe" />


### 参考来源

- [bing2 失效事件记录](https://aishare.jizhiku.net/archives/38305)
- [新端点调用指南（ankio.net）](https://www.ankio.net/research/technology/microsoft-edge-translate-api)
- [Microsoft Edge Translator API 官方文档](https://learn.microsoft.com/en-us/microsoft-edge/web-platform/translator-api)
- [MSEdgeExplainers Translator 反馈 issue #1157](https://github.com/MicrosoftEdge/MSEdgeExplainers/issues/1157)

---

## 二、设置页接口显隐逻辑优化

### 问题

设置页"显示的接口"tab 控制各 OCR/翻译接口在对应 tab 中的显示/隐藏。**修改勾选状态后，必须关闭重开设置窗才能看到效果**——对应 tab 的接口页面不会实时刷新。

### 调整内容

- **实时刷新**：勾选/取消勾选接口后，对应翻译/密钥 tab 的页面立即增删反映显隐，无需关闭重开设置窗
- **修复历史遗留 bug**：百度/腾讯的嵌套密钥子页此前因父容器指向错误，隐藏操作实际不生效（代码中已有「暂时就这样吧」的放弃注释），现已修复
- **配置统一管理**：原本散落在多处的接口配置（事件绑定、初始化读取、保存、使用中保护）统一收敛为一份接口元数据，未来新增接口只需改一处，并消除了大量重复硬编码

---

## 测试

- 新增接口显隐决策逻辑的单元测试（纯函数覆盖显隐动作判定与初始可见性解析）
- 全部单元测试通过（共 46 项）
- 手动回归验证：实时刷新、使用中接口保护、嵌套子页隐藏、配置持久化往返等场景均正常
